### PR TITLE
fix: patch path traversal, YAML deserialization, and CLI input validation

### DIFF
--- a/packages/mdv-cli/src/export-cmd.ts
+++ b/packages/mdv-cli/src/export-cmd.ts
@@ -20,8 +20,8 @@ export async function exportPdfCommand(file: string, outPath: string, pageSize: 
       res.end(printableHtml);
       return;
     }
-    const full = path.join(baseDir, decodeURIComponent((req.url || "").replace(/^\/+/, "")));
-    if (!full.startsWith(baseDir)) { res.writeHead(403); res.end(); return; }
+    const full = path.resolve(baseDir, decodeURIComponent((req.url || "").replace(/^\/+/, "")));
+    if (!full.startsWith(baseDir + path.sep) && full !== baseDir) { res.writeHead(403); res.end(); return; }
     fsSync.readFile(full, (err, data) => {
       if (err) { res.writeHead(404); res.end(); return; }
       res.writeHead(200);

--- a/packages/mdv-cli/src/index.ts
+++ b/packages/mdv-cli/src/index.ts
@@ -28,9 +28,18 @@ async function main() {
     const file = rest[0];
     if (!file || !rest.includes("--pdf")) usage();
     const outIdx = rest.indexOf("--out");
+    if (outIdx >= 0 && !rest[outIdx + 1]) {
+      console.error("Error: --out requires a path argument");
+      process.exit(1);
+    }
     const out = outIdx >= 0 ? rest[outIdx + 1] : file.replace(/\.mdv$/i, "") + ".pdf";
     const psIdx = rest.indexOf("--page-size");
-    const ps = (psIdx >= 0 ? rest[psIdx + 1] : "letter") as "letter" | "a4";
+    const rawPs = psIdx >= 0 ? rest[psIdx + 1] : "letter";
+    if (rawPs !== "letter" && rawPs !== "a4") {
+      console.error("Error: --page-size must be 'letter' or 'a4'");
+      process.exit(1);
+    }
+    const ps = rawPs;
     try {
       await exportPdfCommand(file, out, ps);
     } catch (e) {
@@ -53,6 +62,10 @@ async function main() {
     const file = rest[0];
     if (!file) usage();
     const outIdx = rest.indexOf("--out");
+    if (outIdx >= 0 && !rest[outIdx + 1]) {
+      console.error("Error: --out requires a path argument");
+      process.exit(1);
+    }
     const out = outIdx >= 0 ? rest[outIdx + 1] : file.replace(/\.mdv$/i, "") + ".html";
     try {
       const html = await renderFile(file);

--- a/packages/mdv-cli/src/preview-cmd.ts
+++ b/packages/mdv-cli/src/preview-cmd.ts
@@ -64,8 +64,8 @@ export async function previewCommand(file: string, port: number): Promise<void> 
       return;
     }
     const safe = path.normalize(pathname).replace(/^([/\\])+/, "");
-    const full = path.join(baseDir, safe);
-    if (!full.startsWith(baseDir)) {
+    const full = path.resolve(baseDir, safe);
+    if (!full.startsWith(baseDir + path.sep) && full !== baseDir) {
       res.writeHead(403);
       res.end("forbidden");
       return;

--- a/packages/mdv-core/src/data.ts
+++ b/packages/mdv-core/src/data.ts
@@ -59,6 +59,10 @@ export function parseJson(src: string): Row[] {
 
 export async function loadDataset(relPath: string, baseDir: string): Promise<Row[]> {
   const full = path.resolve(baseDir, relPath);
+  const normalizedBase = path.resolve(baseDir);
+  if (!full.startsWith(normalizedBase + path.sep) && full !== normalizedBase) {
+    throw new Error(`Data file path escapes base directory: ${relPath}`);
+  }
   const src = await fs.readFile(full, "utf8");
   const ext = path.extname(full).toLowerCase();
   if (ext === ".csv" || ext === ".tsv") return parseCsv(src);

--- a/packages/mdv-core/src/frontmatter.ts
+++ b/packages/mdv-core/src/frontmatter.ts
@@ -12,7 +12,7 @@ export function extractFrontmatter(source: string): FrontmatterResult {
   if (!m) return { data: {}, body: source };
   let data: Record<string, unknown>;
   try {
-    const parsed = yaml.load(m[1]);
+    const parsed = yaml.load(m[1], { schema: yaml.DEFAULT_SAFE_SCHEMA });
     data = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
   } catch (e) {
     throw new Error(`Invalid front-matter YAML: ${(e as Error).message}`);


### PR DESCRIPTION
## Summary

This PR addresses several security vulnerabilities and input validation issues found in the mdv codebase:

### Critical Fixes
- **Path traversal in `loadDataset()`** (`data.ts`): Added validation that resolved file paths stay within the base directory, preventing reads of arbitrary files via crafted front-matter `data:` paths (e.g., `../../etc/passwd`).
- **Path traversal in PDF export HTTP server** (`export-cmd.ts`): Replaced `path.join` with `path.resolve` and fixed the `startsWith` guard to use directory-boundary checks (`baseDir + path.sep`), preventing traversal via paths like `/../mdv-evilstuff/`.

### Medium Fixes
- **Same path traversal fix in preview server** (`preview-cmd.ts`): Applied the same `path.resolve` + separator-boundary check to the static file handler.
- **YAML deserialization vulnerability** (`frontmatter.ts`): Switched to `yaml.DEFAULT_SAFE_SCHEMA` to prevent arbitrary JS object instantiation (e.g., `!!js/function`) via malicious front-matter.
- **Unvalidated `--page-size` CLI argument** (`index.ts`): Added runtime validation that only `"letter"` or `"a4"` are accepted, replacing the unsafe `as` type assertion.

### Low Fixes
- **Missing `--out` value validation** (`index.ts`): Both `render` and `export` commands now error if `--out` is passed without a following path argument, preventing writes to an `"undefined"` filename.

## Test plan
- [x] All 24 existing unit tests pass
- [ ] Manual test: create a `.mdv` file with `data: { x: "../../etc/passwd" }` and verify `mdv render` rejects it
- [ ] Manual test: verify `mdv export --page-size malicious` is rejected
- [ ] Manual test: verify `mdv render foo.mdv --out` (no value) is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)