### PR TITLE
fix: harden path traversal in preview/export servers and dataset loader

### DIFF
--- a/packages/mdv-cli/src/export-cmd.ts
+++ b/packages/mdv-cli/src/export-cmd.ts
@@ -20,8 +20,8 @@ export async function exportPdfCommand(file: string, outPath: string, pageSize: 
       res.end(printableHtml);
       return;
     }
-    const full = path.join(baseDir, decodeURIComponent((req.url || "").replace(/^\/+/, "")));
-    if (!full.startsWith(baseDir)) { res.writeHead(403); res.end(); return; }
+    const full = path.resolve(baseDir, decodeURIComponent((req.url || "").replace(/^\/+/, "")));
+    if (!full.startsWith(baseDir + path.sep) && full !== baseDir) { res.writeHead(403); res.end(); return; }
     fsSync.readFile(full, (err, data) => {
       if (err) { res.writeHead(404); res.end(); return; }
       res.writeHead(200);

--- a/packages/mdv-cli/src/export-cmd.ts
+++ b/packages/mdv-cli/src/export-cmd.ts
@@ -21,7 +21,8 @@ export async function exportPdfCommand(file: string, outPath: string, pageSize: 
       return;
     }
     const full = path.resolve(baseDir, decodeURIComponent((req.url || "").replace(/^\/+/, "")));
-    if (!full.startsWith(baseDir + path.sep) && full !== baseDir) { res.writeHead(403); res.end(); return; }
+    const rel = path.relative(baseDir, full);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) { res.writeHead(403); res.end(); return; }
     fsSync.readFile(full, (err, data) => {
       if (err) { res.writeHead(404); res.end(); return; }
       res.writeHead(200);

--- a/packages/mdv-cli/src/index.ts
+++ b/packages/mdv-cli/src/index.ts
@@ -28,9 +28,18 @@ async function main() {
     const file = rest[0];
     if (!file || !rest.includes("--pdf")) usage();
     const outIdx = rest.indexOf("--out");
+    if (outIdx >= 0 && !rest[outIdx + 1]) {
+      console.error("Error: --out requires a path argument");
+      process.exit(1);
+    }
     const out = outIdx >= 0 ? rest[outIdx + 1] : file.replace(/\.mdv$/i, "") + ".pdf";
     const psIdx = rest.indexOf("--page-size");
-    const ps = (psIdx >= 0 ? rest[psIdx + 1] : "letter") as "letter" | "a4";
+    const rawPs = psIdx >= 0 ? rest[psIdx + 1] : "letter";
+    if (rawPs !== "letter" && rawPs !== "a4") {
+      console.error("Error: --page-size must be 'letter' or 'a4'");
+      process.exit(1);
+    }
+    const ps = rawPs;
     try {
       await exportPdfCommand(file, out, ps);
     } catch (e) {
@@ -53,6 +62,10 @@ async function main() {
     const file = rest[0];
     if (!file) usage();
     const outIdx = rest.indexOf("--out");
+    if (outIdx >= 0 && !rest[outIdx + 1]) {
+      console.error("Error: --out requires a path argument");
+      process.exit(1);
+    }
     const out = outIdx >= 0 ? rest[outIdx + 1] : file.replace(/\.mdv$/i, "") + ".html";
     try {
       const html = await renderFile(file);

--- a/packages/mdv-cli/src/preview-cmd.ts
+++ b/packages/mdv-cli/src/preview-cmd.ts
@@ -64,8 +64,8 @@ export async function previewCommand(file: string, port: number): Promise<void> 
       return;
     }
     const safe = path.normalize(pathname).replace(/^([/\\])+/, "");
-    const full = path.join(baseDir, safe);
-    if (!full.startsWith(baseDir)) {
+    const full = path.resolve(baseDir, safe);
+    if (!full.startsWith(baseDir + path.sep) && full !== baseDir) {
       res.writeHead(403);
       res.end("forbidden");
       return;

--- a/packages/mdv-cli/src/preview-cmd.ts
+++ b/packages/mdv-cli/src/preview-cmd.ts
@@ -65,7 +65,8 @@ export async function previewCommand(file: string, port: number): Promise<void> 
     }
     const safe = path.normalize(pathname).replace(/^([/\\])+/, "");
     const full = path.resolve(baseDir, safe);
-    if (!full.startsWith(baseDir + path.sep) && full !== baseDir) {
+    const rel = path.relative(baseDir, full);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
       res.writeHead(403);
       res.end("forbidden");
       return;

--- a/packages/mdv-core/src/data.ts
+++ b/packages/mdv-core/src/data.ts
@@ -59,6 +59,10 @@ export function parseJson(src: string): Row[] {
 
 export async function loadDataset(relPath: string, baseDir: string): Promise<Row[]> {
   const full = path.resolve(baseDir, relPath);
+  const normalizedBase = path.resolve(baseDir);
+  if (!full.startsWith(normalizedBase + path.sep) && full !== normalizedBase) {
+    throw new Error(`Data file path escapes base directory: ${relPath}`);
+  }
   const src = await fs.readFile(full, "utf8");
   const ext = path.extname(full).toLowerCase();
   if (ext === ".csv" || ext === ".tsv") return parseCsv(src);

--- a/packages/mdv-core/src/data.ts
+++ b/packages/mdv-core/src/data.ts
@@ -58,9 +58,10 @@ export function parseJson(src: string): Row[] {
 }
 
 export async function loadDataset(relPath: string, baseDir: string): Promise<Row[]> {
-  const full = path.resolve(baseDir, relPath);
   const normalizedBase = path.resolve(baseDir);
-  if (!full.startsWith(normalizedBase + path.sep) && full !== normalizedBase) {
+  const full = path.resolve(normalizedBase, relPath);
+  const rel = path.relative(normalizedBase, full);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
     throw new Error(`Data file path escapes base directory: ${relPath}`);
   }
   const src = await fs.readFile(full, "utf8");

--- a/packages/mdv-core/src/frontmatter.ts
+++ b/packages/mdv-core/src/frontmatter.ts
@@ -12,7 +12,7 @@ export function extractFrontmatter(source: string): FrontmatterResult {
   if (!m) return { data: {}, body: source };
   let data: Record<string, unknown>;
   try {
-    const parsed = yaml.load(m[1]);
+    const parsed = yaml.load(m[1], { schema: yaml.DEFAULT_SAFE_SCHEMA });
     data = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
   } catch (e) {
     throw new Error(`Invalid front-matter YAML: ${(e as Error).message}`);

--- a/packages/mdv-core/src/frontmatter.ts
+++ b/packages/mdv-core/src/frontmatter.ts
@@ -12,7 +12,7 @@ export function extractFrontmatter(source: string): FrontmatterResult {
   if (!m) return { data: {}, body: source };
   let data: Record<string, unknown>;
   try {
-    const parsed = yaml.load(m[1], { schema: yaml.DEFAULT_SAFE_SCHEMA });
+    const parsed = yaml.load(m[1]);
     data = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
   } catch (e) {
     throw new Error(`Invalid front-matter YAML: ${(e as Error).message}`);


### PR DESCRIPTION
Supersedes #8 (closes it). Same path-traversal hardening by @hobostay, with the broken YAML change reverted so the build passes.

## Summary
- **Path traversal**: switch preview and export static-file servers from ``path.join + startsWith(baseDir)`` to ``path.resolve + startsWith(baseDir + path.sep)``. Closes a prefix-match bypass where ``/home/app`` would also match ``/home/app-evil/…``. (``packages/mdv-cli/src/export-cmd.ts``, ``packages/mdv-cli/src/preview-cmd.ts``)
- **Dataset containment**: add the same check to ``loadDataset`` so a front-matter ``data:`` ref cannot escape the document's base directory. (``packages/mdv-core/src/data.ts``)
- **CLI arg validation**: error clearly when ``--out`` has no value, and reject ``--page-size`` values other than ``letter``/``a4``. (``packages/mdv-cli/src/index.ts``)
- **Reverted**: the ``yaml.load(…, { schema: yaml.DEFAULT_SAFE_SCHEMA })`` change from #8. ``DEFAULT_SAFE_SCHEMA`` doesn't exist in js-yaml v4 — it broke TypeScript compilation, and ``yaml.load`` in v4 is already safe (no ``!!js/function`` etc.).

Credit to @hobostay for the original analysis and fixes in #8.

## Test plan
- [x] ``npm run build`` succeeds on all workspaces
- [x] ``npm test`` — 24/24 pass in @mdv/core
- [ ] CI green on Node 20 and 22

Co-Authored-By: hobostay