### PR TITLE
feat(site): static landing/gallery + GitHub Pages workflow (closes #16)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,56 @@
+name: Deploy site to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install
+        run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"
+
+      - name: Build core
+        run: npm run build --workspace @mdv/core
+
+      - name: Build site
+        run: npm run build:site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ Thumbs.db
 # Rendered output — keep example outputs, ignore everything else
 *.html
 !examples/**/*.html
+!scripts/site-template/*.html
 *.pdf
 !examples/**/*.pdf
 
@@ -39,3 +40,6 @@ Thumbs.db
 # Private / internal docs — planning specs, implementation plans, launch drafts
 docs/superpowers/
 docs/launch/
+
+# Generated site (built by scripts/build-site.mjs, deployed via Pages workflow)
+site/

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "build": "npm run build --workspace @mdv/core && npm run build --workspace @mdv/cli && npm run build --workspace mdv-vscode",
+    "build:site": "node scripts/build-site.mjs",
     "test": "npm run test --workspaces --if-present"
   },
   "devDependencies": {

--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { renderFile } from "@mdv/core";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+const SITE = path.join(ROOT, "site");
+const TEMPLATE = path.join(ROOT, "scripts", "site-template");
+const EXAMPLES_OUT = path.join(ROOT, "examples", "out");
+const EXAMPLES_SRC = path.join(ROOT, "examples");
+const DOCS_SRC = path.join(ROOT, "docs");
+
+const EXAMPLES = [
+  { id: "01-plain-markdown", title: "Plain Markdown", blurb: "Pure CommonMark — proves MDV is a strict superset." },
+  { id: "02-named-style", title: "Named styles", blurb: "Define and reuse styled regions from front-matter." },
+  { id: "03-bar-chart-inline", title: "Bar chart (inline CSV)", blurb: "Single-series bar chart from inline data." },
+  { id: "04-line-chart-inline", title: "Line chart (inline CSV)", blurb: "Multi-series line chart with currency axis." },
+  { id: "05-pie-chart-inline", title: "Pie chart (inline CSV)", blurb: "Pie chart with categorical breakdown." },
+  { id: "06-table", title: "Table", blurb: "Tabular data block — same syntax as charts." },
+  { id: "07-data-file-ref", title: "External data file", blurb: "Reference a CSV from front-matter `data:` and chart it." },
+  { id: "08-columns-layout", title: "Columns layout", blurb: "`::: columns` containers for side-by-side regions." },
+  { id: "09-full-report", title: "Full quarterly report", blurb: "All v1 features composed into a polished report." },
+  { id: "10-new-features", title: "Latest additions", blurb: "TOC, currency axes, and multi-series charts." },
+];
+
+const DOCS = [
+  { file: "getting-started.md", title: "Getting started", blurb: "Install, author your first file, see it rendered." },
+  { file: "syntax.md", title: "Syntax reference", blurb: "Front-matter, fenced blocks, `:::` containers." },
+  { file: "charts.md", title: "Charts & stats", blurb: "Every visualization type with all options." },
+  { file: "data.md", title: "Data", blurb: "Inline CSV / JSON and file-referenced datasets." },
+  { file: "themes-and-styles.md", title: "Themes & styles", blurb: "Built-in themes and how to define named styles." },
+  { file: "cli.md", title: "CLI", blurb: "`render`, `preview`, `export --pdf`." },
+  { file: "vscode.md", title: "VS Code extension", blurb: "Side-by-side live preview." },
+  { file: "publishing-vscode-extension.md", title: "Publishing the VS Code extension", blurb: "Marketplace workflow." },
+];
+
+async function rmrf(dir) {
+  await fs.rm(dir, { recursive: true, force: true });
+}
+
+async function ensureDir(dir) {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+async function copyFile(from, to) {
+  await ensureDir(path.dirname(to));
+  await fs.copyFile(from, to);
+}
+
+async function readTemplate(name) {
+  return fs.readFile(path.join(TEMPLATE, name), "utf8");
+}
+
+function fillTemplate(tpl, vars) {
+  return tpl.replace(/\{\{(\w+)\}\}/g, (_, k) => (k in vars ? vars[k] : ""));
+}
+
+function escapeHtml(s) {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+async function buildExamplesGallery(shell) {
+  const cards = EXAMPLES.map((e) => `
+    <div class="card card-split">
+      <a class="card-main" href="examples/${e.id}.html">
+        <h3>${escapeHtml(e.title)}</h3>
+        <p>${escapeHtml(e.blurb)}</p>
+      </a>
+      <div class="card-foot">
+        <a class="meta" href="examples/${e.id}.html">View rendered →</a>
+        <a class="meta-link" href="examples/source/${e.id}.mdv">source</a>
+      </div>
+    </div>`).join("\n");
+
+  const body = `
+    <section class="page-head">
+      <h1>Examples</h1>
+      <p>Every v1 feature, end to end. Each card opens the rendered output; the <code>source</code> link shows the original <code>.mdv</code> input.</p>
+    </section>
+    <section class="card-grid">${cards}</section>`;
+
+  return fillTemplate(shell, {
+    title: "Examples — MDV",
+    active_examples: "active",
+    active_docs: "",
+    active_home: "",
+    body,
+    base: "./",
+  });
+}
+
+async function buildDocsIndex(shell) {
+  const cards = DOCS.map((d) => {
+    const slug = d.file.replace(/\.md$/, "");
+    return `
+    <a class="card" href="docs/${slug}.html">
+      <h3>${escapeHtml(d.title)}</h3>
+      <p>${escapeHtml(d.blurb)}</p>
+      <div class="card-foot"><span class="meta">Read →</span></div>
+    </a>`;
+  }).join("\n");
+
+  const body = `
+    <section class="page-head">
+      <h1>Documentation</h1>
+      <p>Reference material for authors and contributors.</p>
+    </section>
+    <section class="card-grid">${cards}</section>`;
+
+  return fillTemplate(shell, {
+    title: "Documentation — MDV",
+    active_examples: "",
+    active_docs: "active",
+    active_home: "",
+    body,
+    base: "./",
+  });
+}
+
+async function renderDoc(file) {
+  const full = path.join(DOCS_SRC, file);
+  return renderFile(full);
+}
+
+function wrapDocPage(shell, title, mdvHtml) {
+  const startBody = mdvHtml.indexOf("<body>") + "<body>".length;
+  const endBody = mdvHtml.indexOf("</body>");
+  const inner = mdvHtml.slice(startBody, endBody).trim();
+  const body = `<section class="doc-content">${inner}</section>`;
+  return fillTemplate(shell, {
+    title: `${title} — MDV`,
+    active_examples: "",
+    active_docs: "active",
+    active_home: "",
+    body,
+    base: "../",
+  });
+}
+
+async function main() {
+  console.log("Building site/...");
+  await rmrf(SITE);
+  await ensureDir(SITE);
+
+  const shell = await readTemplate("shell.html");
+  const indexBody = await readTemplate("index-body.html");
+  const css = await readTemplate("site.css");
+
+  // Landing
+  const landingHtml = fillTemplate(shell, {
+    title: "MDV — Markdown Data & Visualization",
+    active_examples: "",
+    active_docs: "",
+    active_home: "active",
+    body: indexBody,
+    base: "./",
+  });
+  await fs.writeFile(path.join(SITE, "index.html"), landingHtml, "utf8");
+
+  // Shared CSS
+  await ensureDir(path.join(SITE, "assets"));
+  await fs.writeFile(path.join(SITE, "assets", "site.css"), css, "utf8");
+
+  // Examples gallery
+  const galleryHtml = await buildExamplesGallery(shell);
+  await fs.writeFile(path.join(SITE, "examples.html"), galleryHtml, "utf8");
+
+  // Copy rendered example HTML + sources
+  await ensureDir(path.join(SITE, "examples"));
+  await ensureDir(path.join(SITE, "examples", "source"));
+  for (const e of EXAMPLES) {
+    await copyFile(path.join(EXAMPLES_OUT, `${e.id}.html`), path.join(SITE, "examples", `${e.id}.html`));
+    await copyFile(path.join(EXAMPLES_SRC, `${e.id}.mdv`), path.join(SITE, "examples", "source", `${e.id}.mdv`));
+  }
+
+  // Docs index + rendered docs
+  const docsIndexHtml = await buildDocsIndex(shell);
+  await fs.writeFile(path.join(SITE, "docs.html"), docsIndexHtml, "utf8");
+  await ensureDir(path.join(SITE, "docs"));
+  for (const d of DOCS) {
+    const rendered = await renderDoc(d.file);
+    const wrapped = wrapDocPage(shell, d.title, rendered);
+    const slug = d.file.replace(/\.md$/, "");
+    await fs.writeFile(path.join(SITE, "docs", `${slug}.html`), wrapped, "utf8");
+  }
+
+  console.log(`Wrote site/ — ${EXAMPLES.length} examples, ${DOCS.length} docs`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/site-template/index-body.html
+++ b/scripts/site-template/index-body.html
@@ -1,0 +1,63 @@
+<section class="hero">
+  <h1>Reports, dashboards, slide decks — one Markdown source.</h1>
+  <p class="lead">Write reports, dashboards, and slide decks in a single Markdown-native workflow, then export to self-contained HTML or PDF — no rebuilding the same content across a doc tool, a BI tool, and a deck tool.</p>
+  <div class="cta-row">
+    <a class="btn primary" href="examples.html">See examples</a>
+    <a class="btn" href="docs/getting-started.html">Get started</a>
+  </div>
+</section>
+
+<section class="syntax-row">
+  <div class="syntax-text">
+    <h2>Strict CommonMark, plus four additions.</h2>
+    <p>Every valid <code>.md</code> file is a valid <code>.mdv</code> file. The four additions are the only thing standing between a plain document and a charted, themed, multi-page report.</p>
+    <ol>
+      <li><strong>YAML front-matter</strong> for title, theme, named styles, and dataset references.</li>
+      <li><strong>Fenced blocks</strong> for data and visuals: <code>```chart type=bar x=region y=sales</code>.</li>
+      <li><strong><code>:::</code> containers</strong> for styled regions and layout: <code>::: callout</code>, <code>::: columns</code>.</li>
+      <li><strong><code>::: toc</code></strong> for an auto-generated table of contents.</li>
+    </ol>
+  </div>
+  <div class="syntax-code">
+<pre><code>---
+title: Q1 Report
+theme: report
+data:
+  sales: ./data/sales.csv
+---
+
+::: toc
+:::
+
+# Q1 Results
+
+```stat
+label, value, delta
+Total revenue, $2.06M, +14%
+New customers, 1238, +8%
+```
+
+```chart type=line data=sales x=month y=revenue
+       series=region yFormat=currency
+       title="Monthly revenue"
+```</code></pre>
+  </div>
+</section>
+
+<section class="quick-cards">
+  <a class="card" href="examples.html">
+    <h3>Examples</h3>
+    <p>Ten rendered <code>.mdv</code> files showing every feature — from plain Markdown through a full quarterly report with multi-series charts and named styles.</p>
+    <div class="card-foot"><span class="meta">Browse →</span></div>
+  </a>
+  <a class="card" href="docs.html">
+    <h3>Documentation</h3>
+    <p>Syntax reference, charts, data, themes, and the CLI. The reference is itself rendered with MDV — eat your own dogfood.</p>
+    <div class="card-foot"><span class="meta">Read →</span></div>
+  </a>
+  <a class="card" href="https://github.com/drasimwagan/mdv#getting-started">
+    <h3>Install</h3>
+    <p>Clone the repo, run <code>npm install</code>, render an example. Live preview with auto-reload via <code>mdv preview</code>, or use the VS Code extension.</p>
+    <div class="card-foot"><span class="meta">Get the code →</span></div>
+  </a>
+</section>

--- a/scripts/site-template/shell.html
+++ b/scripts/site-template/shell.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{title}}</title>
+<link rel="stylesheet" href="{{base}}assets/site.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="brand" href="{{base}}index.html">
+    <span class="brand-mark">MDV</span>
+    <span class="brand-tag">Markdown Data &amp; Visualization</span>
+  </a>
+  <nav class="topnav">
+    <a class="{{active_home}}" href="{{base}}index.html">Home</a>
+    <a class="{{active_examples}}" href="{{base}}examples.html">Examples</a>
+    <a class="{{active_docs}}" href="{{base}}docs.html">Docs</a>
+    <a href="https://github.com/drasimwagan/mdv" target="_blank" rel="noopener">GitHub ↗</a>
+  </nav>
+</header>
+<main class="main">
+{{body}}
+</main>
+<footer class="foot">
+  <p>MDV is open source under the MIT license. <a href="https://github.com/drasimwagan/mdv">Contribute on GitHub</a>.</p>
+</footer>
+</body>
+</html>

--- a/scripts/site-template/site.css
+++ b/scripts/site-template/site.css
@@ -1,0 +1,235 @@
+:root {
+  --bg: #fdfcf8;
+  --surface: #ffffff;
+  --ink: #1a1a1a;
+  --ink-soft: #4a4a4a;
+  --ink-muted: #707070;
+  --line: rgba(0, 0, 0, 0.08);
+  --line-strong: rgba(0, 0, 0, 0.16);
+  --accent: #2d6cdf;
+  --accent-soft: #e8f0ff;
+  --code-bg: #f5f2ea;
+  --max: 1080px;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+code, pre {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+code { background: var(--code-bg); padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.92em; }
+
+pre {
+  background: var(--code-bg);
+  padding: 16px 20px;
+  border-radius: 6px;
+  overflow-x: auto;
+  font-size: 0.86em;
+  line-height: 1.55;
+  border: 1px solid var(--line);
+}
+
+pre code { background: none; padding: 0; }
+
+/* topbar */
+.topbar {
+  border-bottom: 1px solid var(--line);
+  padding: 16px 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  background: var(--surface);
+}
+
+.brand { display: flex; align-items: baseline; gap: 10px; color: var(--ink); }
+.brand:hover { text-decoration: none; }
+.brand-mark { font-weight: 700; letter-spacing: 0.02em; font-size: 1.15rem; }
+.brand-tag { color: var(--ink-muted); font-size: 0.92rem; }
+
+.topnav { display: flex; gap: 20px; align-items: center; }
+.topnav a {
+  color: var(--ink-soft);
+  font-size: 0.94rem;
+  padding: 4px 0;
+  border-bottom: 2px solid transparent;
+}
+.topnav a:hover { color: var(--ink); text-decoration: none; }
+.topnav a.active { color: var(--ink); border-bottom-color: var(--accent); }
+
+/* main */
+.main { max-width: var(--max); margin: 0 auto; padding: 48px 24px 64px; }
+
+/* hero */
+.hero { margin: 8px 0 56px; }
+.hero h1 {
+  font-size: 2.6rem;
+  line-height: 1.15;
+  margin: 0 0 16px;
+  letter-spacing: -0.02em;
+  font-weight: 700;
+  max-width: 880px;
+}
+.hero .lead {
+  font-size: 1.15rem;
+  color: var(--ink-soft);
+  max-width: 720px;
+  margin: 0 0 28px;
+}
+.cta-row { display: flex; gap: 12px; flex-wrap: wrap; }
+
+.btn {
+  display: inline-block;
+  padding: 10px 20px;
+  border-radius: 4px;
+  border: 1px solid var(--line-strong);
+  background: var(--surface);
+  color: var(--ink);
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+.btn:hover { text-decoration: none; border-color: var(--ink-soft); }
+.btn.primary {
+  background: var(--ink);
+  color: var(--bg);
+  border-color: var(--ink);
+}
+.btn.primary:hover { background: var(--ink-soft); border-color: var(--ink-soft); }
+
+/* syntax row */
+.syntax-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 48px;
+  align-items: start;
+  margin: 48px 0 64px;
+}
+.syntax-text h2 {
+  margin-top: 0;
+  font-size: 1.55rem;
+  letter-spacing: -0.01em;
+}
+.syntax-text ol { padding-left: 1.2em; }
+.syntax-text li { margin: 6px 0; color: var(--ink-soft); }
+.syntax-text li strong { color: var(--ink); }
+.syntax-code pre { margin: 0; }
+
+@media (max-width: 760px) {
+  .syntax-row { grid-template-columns: 1fr; gap: 24px; }
+  .hero h1 { font-size: 2rem; }
+}
+
+/* card grid */
+.quick-cards, .card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+  margin-top: 32px;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  padding: 20px 22px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--ink);
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+a.card:hover {
+  text-decoration: none;
+  border-color: var(--ink-soft);
+  transform: translateY(-2px);
+}
+.card-split { padding: 0; }
+.card-split .card-main {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 20px 22px 12px;
+  color: var(--ink);
+  border-radius: 6px 6px 0 0;
+}
+.card-split .card-main:hover { text-decoration: none; }
+.card-split:hover { border-color: var(--ink-soft); transform: translateY(-2px); }
+.card-split .card-foot {
+  padding: 12px 22px 16px;
+  border-top: 1px solid var(--line);
+  background: rgba(0, 0, 0, 0.015);
+  border-radius: 0 0 6px 6px;
+}
+.card h3 {
+  margin: 0 0 8px;
+  font-size: 1.08rem;
+  letter-spacing: -0.005em;
+}
+.card p {
+  color: var(--ink-soft);
+  font-size: 0.95rem;
+  margin: 0 0 12px;
+  flex: 1;
+}
+.card-foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: auto;
+}
+.meta { color: var(--accent); font-size: 0.88rem; }
+.meta-link { color: var(--ink-muted); font-size: 0.84rem; }
+
+/* page heads */
+.page-head h1 {
+  margin: 0 0 8px;
+  font-size: 2rem;
+  letter-spacing: -0.015em;
+}
+.page-head p { color: var(--ink-soft); margin: 0 0 24px; max-width: 720px; }
+
+/* doc content (rendered MDV bodies inserted here) */
+.doc-content {
+  max-width: 760px;
+  font-size: 1rem;
+  line-height: 1.7;
+}
+.doc-content h1 { font-size: 2rem; letter-spacing: -0.015em; margin-top: 0; }
+.doc-content h2 { font-size: 1.4rem; margin-top: 1.8em; }
+.doc-content h3 { font-size: 1.1rem; margin-top: 1.4em; }
+.doc-content table { border-collapse: collapse; margin: 1em 0; width: 100%; }
+.doc-content th, .doc-content td { border-bottom: 1px solid var(--line); padding: 8px 12px; text-align: left; }
+.doc-content th { border-bottom: 2px solid var(--accent); }
+.doc-content blockquote {
+  margin: 1em 0;
+  padding: 4px 16px;
+  border-left: 3px solid var(--accent);
+  color: var(--ink-soft);
+}
+
+/* footer */
+.foot {
+  border-top: 1px solid var(--line);
+  margin-top: 64px;
+  padding: 24px;
+  text-align: center;
+  color: var(--ink-muted);
+  font-size: 0.92rem;
+  background: var(--surface);
+}
+.foot p { margin: 0; }


### PR DESCRIPTION
## Summary

Addresses #16 — a small static site to host the rendered examples plus docs, deployable to GitHub Pages on every push to main.

- **Landing** (\`index.html\`): hero matching the README tagline, syntax overview with inline code sample, three quick-start cards (Examples / Docs / Install).
- **Examples gallery** (\`examples.html\`): all 10 rendered outputs as a card grid, each card links to both the rendered HTML and the raw \`.mdv\` source.
- **Docs** (\`docs.html\` + \`docs/*.html\`): docs landing plus rendered docs — and the docs are rendered with \`@mdv/core\` itself, dogfood-style.
- **Build script** \`scripts/build-site.mjs\`: reads from existing \`examples/out/\` and \`docs/\`, writes to \`site/\` (gitignored).
- **CI** \`.github/workflows/pages.yml\`: builds core, runs the site build, deploys via \`actions/deploy-pages@v4\`.

Deliberately **not in v1**: interactive editor (out of scope; would warrant its own design pass).

After this lands you'll need to flip on GitHub Pages in repo Settings → Pages → Source: GitHub Actions for the deploy to actually publish.

Verified locally with Playwright: home, examples gallery, docs landing, rendered example with charts — all render cleanly.

## Test plan
- [x] \`npm run build:site\` succeeds; output structure looks right
- [x] Visual check of /, /examples.html, /docs.html, /docs/syntax.html, /examples/09-full-report.html
- [ ] CI passes on Node 20 + 22 (build still works after this change)
- [ ] After enabling Pages: workflow deploys and the site is reachable at the Pages URL