### PR TITLE
ci: restrict GITHUB_TOKEN to contents:read in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Build & test (Node ${{ matrix.node }})


### PR DESCRIPTION
Closes the actions/missing-workflow-permissions CodeQL warning. The CI workflow only reads the repo; explicit `permissions: { contents: read }` locks the token down.