### PR TITLE
v0.2.0 — correctness, security & robustness hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+All notable changes to MDV are documented here. This project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html) (pre-1.0: minor
+versions may include behavior changes).
+
+## [0.2.0] — 2026-07-07
+
+A correctness and robustness release. The renderer is now hardened against the
+most common author mistakes and against untrusted `.mdv`/`.md` input, and no
+longer silently produces wrong output.
+
+### Security
+
+- **Raw HTML is no longer emitted.** The parser runs markdown-it with
+  `html: false`; `<script>`/raw markup in the document body is escaped, not
+  passed through into exported HTML.
+- **Front-matter style values are sanitized.** A named-style value can no
+  longer break out of the `<style>` element (e.g. `color: "red } </style>…"`);
+  offending declarations are dropped with a warning.
+
+### Fixed
+
+- **CommonMark-superset guarantee.** `:::` directives are now handled by a
+  fence-aware pre-pass instead of a naive line rewrite, so `:::` shown inside a
+  fenced code block stays literal and documents that document MDV syntax render
+  identically under plain Markdown. Directives also interact correctly with
+  blockquotes, tables and lists.
+- **Errors never crash or corrupt the document.** Invalid front-matter YAML now
+  renders a fatal banner at the top of the document (the body still renders)
+  instead of throwing; every block renders inside a guard; unmatched/unclosed
+  `:::` containers produce a warning and balanced HTML rather than orphaned
+  `</div>`s.
+- **Charts validate their inputs.** A misspelled or missing `x`/`y`/`label`/
+  `value` column, or a non-numeric value, now renders an inline red banner
+  instead of silently-wrong output. Empty/blank cells render as zero.
+- **Chart geometry.** Bar charts anchor to a zero baseline (all-negative data
+  stays in view); a 100% pie slice renders as a full disc; negative pie values
+  are rejected; single-point line series show a visible marker.
+- **Data.** `.tsv` datasets parse with a tab delimiter; ragged CSV rows emit a
+  delimiter-aware warning (benign trailing commas do not); `format=json`
+  rejects non-object arrays; a missing data file reports the author's relative
+  path, never an absolute local path.
+- **HTML comments.** A standalone `<!-- … -->` line is hidden; inline,
+  multi-line and unterminated comments are left untouched (never destructive).
+- **CLI.** `mdv render` prints fatal/warning diagnostics to stderr and gains
+  `--strict` (non-zero exit on fatal errors); the preview server binds to
+  `127.0.0.1` only, validates `--port`, and reports `EADDRINUSE` cleanly;
+  `--out` creates missing parent directories; file-not-found messages are
+  friendly and leak no absolute paths.
+- A `theme:` name matching an `Object.prototype` key (e.g. `constructor`) no
+  longer crashes the render.
+
+### Added
+
+- `renderFileWithDiagnostics()` in `@mdv/core`, returning `{ html, fatals,
+  warnings }`.
+- `mdv render --strict` for CI gating.
+
+### Notes
+
+- Under `html: false`, inline/multi-line HTML comments now render as visible
+  (escaped) text rather than being invisible as in 0.1.x. Put private notes on
+  their own line as a complete `<!-- … -->` to keep them hidden.
+
+## [0.1.1] — earlier
+
+- VS Code extension: initial Marketplace release.
+
+## [0.1.0] — earlier
+
+- Initial MDV: CommonMark superset with front-matter, `chart`/`table`/`stat`
+  fenced blocks, `:::` containers, themes and named styles, TOC, and
+  HTML/PDF export.

--- a/examples/10-new-features.mdv
+++ b/examples/10-new-features.mdv
@@ -13,7 +13,7 @@ theme: minimal
 ```stat
 label, value, delta
 Total revenue, $2.06M, +14%
-New customers, 1,238, +8%
+New customers, "1,238", +8%
 Churn rate, 2.1%, -0.4%
 NPS, 62, +6
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -5261,9 +5261,9 @@
     },
     "packages/mdv-cli": {
       "name": "@mdv/cli",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
-        "@mdv/core": "0.1.0",
+        "@mdv/core": "0.2.0",
         "puppeteer": "^24.43.0"
       },
       "bin": {
@@ -5272,7 +5272,7 @@
     },
     "packages/mdv-core": {
       "name": "@mdv/core",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "js-yaml": "^4.3.0",
         "markdown-it": "^14.2.0"
@@ -5283,10 +5283,10 @@
       }
     },
     "packages/mdv-vscode": {
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
-        "@mdv/core": "0.1.0",
+        "@mdv/core": "0.2.0",
         "@types/vscode": "^1.125.0",
         "@vscode/vsce": "^3.9.2",
         "esbuild": "^0.28.1"

--- a/packages/mdv-cli/package.json
+++ b/packages/mdv-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdv/cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "bin": {
     "mdv": "dist/index.js"
@@ -9,7 +9,7 @@
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@mdv/core": "0.1.0",
+    "@mdv/core": "0.2.0",
     "puppeteer": "^24.43.0"
   }
 }

--- a/packages/mdv-cli/src/export-cmd.ts
+++ b/packages/mdv-cli/src/export-cmd.ts
@@ -38,6 +38,7 @@ export async function exportPdfCommand(file: string, outPath: string, pageSize: 
     const page = await browser.newPage();
     await page.goto(`http://localhost:${port}/`, { waitUntil: "networkidle0" });
     const pdf = await page.pdf({ format: pageSize === "a4" ? "A4" : "Letter", printBackground: true });
+    await fs.mkdir(path.dirname(path.resolve(outPath)), { recursive: true });
     await fs.writeFile(outPath, pdf);
   } finally {
     await browser.close();

--- a/packages/mdv-cli/src/index.ts
+++ b/packages/mdv-cli/src/index.ts
@@ -1,9 +1,15 @@
 #!/usr/bin/env node
 import fs from "node:fs/promises";
 import path from "node:path";
-import { renderFile, VERSION } from "@mdv/core";
+import { renderFile, renderFileWithDiagnostics, VERSION } from "@mdv/core";
 import { previewCommand } from "./preview-cmd.js";
 import { exportPdfCommand } from "./export-cmd.js";
+
+function friendlyError(e: unknown, file: string): string {
+  const err = e as NodeJS.ErrnoException;
+  if (err.code === "ENOENT") return `file not found: ${file}`;
+  return err.message;
+}
 
 function usage(): never {
   console.error("mdv — render MDV documents");
@@ -43,7 +49,7 @@ async function main() {
     try {
       await exportPdfCommand(file, out, ps);
     } catch (e) {
-      console.error(`Error: ${(e as Error).message}`);
+      console.error(`Error: ${friendlyError(e, file)}`);
       process.exit(1);
     }
     return;
@@ -53,7 +59,12 @@ async function main() {
     const file = rest[0];
     if (!file) usage();
     const portIdx = rest.indexOf("--port");
-    const port = portIdx >= 0 ? Number(rest[portIdx + 1]) : 3000;
+    const portRaw = portIdx >= 0 ? rest[portIdx + 1] : "3000";
+    const port = Number(portRaw);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      console.error(`Error: invalid --port '${portRaw ?? ""}' — expected a number between 1 and 65535`);
+      process.exit(1);
+    }
     await previewCommand(file, port);
     return;
   }
@@ -67,12 +78,20 @@ async function main() {
       process.exit(1);
     }
     const out = outIdx >= 0 ? rest[outIdx + 1] : file.replace(/\.mdv$/i, "") + ".html";
+    const strict = rest.includes("--strict");
     try {
-      const html = await renderFile(file);
+      const { html, fatals, warnings } = await renderFileWithDiagnostics(file);
+      await fs.mkdir(path.dirname(path.resolve(out)), { recursive: true });
       await fs.writeFile(out, html, "utf8");
       console.error(`Rendered ${file} -> ${path.resolve(out)}`);
+      // The document renders regardless (errors never crash the doc), but the
+      // author should still see problems on the terminal.
+      for (const f of fatals) console.error(`  fatal: ${f}`);
+      for (const w of warnings) console.error(`  warning: ${w}`);
+      // --strict makes fatal document errors fail the command, for CI gating.
+      if (strict && fatals.length) process.exit(1);
     } catch (e) {
-      console.error(`Error: ${(e as Error).message}`);
+      console.error(`Error: ${friendlyError(e, file)}`);
       process.exit(1);
     }
     return;

--- a/packages/mdv-cli/src/preview-cmd.ts
+++ b/packages/mdv-cli/src/preview-cmd.ts
@@ -24,6 +24,13 @@ const RELOAD_SNIPPET = `
 export async function previewCommand(file: string, port: number): Promise<void> {
   const absFile = path.resolve(file);
   const baseDir = path.dirname(absFile);
+  // The file itself may not exist yet — the server serves an error page and
+  // live-reloads once it is created. But the directory must exist, or the
+  // recursive watcher below throws.
+  if (!fs.existsSync(baseDir)) {
+    console.error(`Error: directory not found: ${path.dirname(file)}`);
+    process.exit(1);
+  }
   let version = 0;
   let lastError: string | null = null;
 
@@ -45,7 +52,8 @@ export async function previewCommand(file: string, port: number): Promise<void> 
       lastError = null;
       return html.replace(/<\/body>/, RELOAD_SNIPPET + "</body>");
     } catch (e) {
-      lastError = (e as Error).message;
+      const code = (e as NodeJS.ErrnoException).code;
+      lastError = code === "ENOENT" ? `File not found: ${file}` : (e as Error).message;
       return errorPage(lastError, file);
     }
   }
@@ -93,7 +101,19 @@ export async function previewCommand(file: string, port: number): Promise<void> 
     });
   });
 
-  server.listen(port, () => {
+  server.on("error", (err: NodeJS.ErrnoException) => {
+    if (err.code === "EADDRINUSE") {
+      console.error(`Error: port ${port} is already in use — try --port ${port + 1}`);
+    } else {
+      console.error(`Error: could not start preview server: ${err.message}`);
+    }
+    watcher.close();
+    process.exit(1);
+  });
+
+  // Bind to loopback only — the preview server renders local files and must
+  // not be reachable from the rest of the network.
+  server.listen(port, "127.0.0.1", () => {
     console.error(`[mdv] preview of ${file} at http://localhost:${port}`);
     console.error(`[mdv] watching ${baseDir} for changes; Ctrl+C to stop`);
   });

--- a/packages/mdv-core/package.json
+++ b/packages/mdv-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdv/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mdv-core/src/data.ts
+++ b/packages/mdv-core/src/data.ts
@@ -3,6 +3,11 @@ import path from "node:path";
 
 export type Row = Record<string, string | number | boolean | null>;
 
+export interface CsvParseResult {
+  rows: Row[];
+  warnings: string[];
+}
+
 function coerce(v: string): string | number | boolean | null {
   const t = v.trim();
   if (t === "") return "";
@@ -13,7 +18,7 @@ function coerce(v: string): string | number | boolean | null {
   return t;
 }
 
-export function parseCsv(src: string): Row[] {
+export function parseCsvFull(src: string, delimiter = ","): CsvParseResult {
   const lines: string[][] = [];
   let cur: string[] = [];
   let field = "";
@@ -26,7 +31,7 @@ export function parseCsv(src: string): Row[] {
       else field += c;
     } else {
       if (c === '"') inQuotes = true;
-      else if (c === ",") { cur.push(field); field = ""; }
+      else if (c === delimiter) { cur.push(field); field = ""; }
       else if (c === "\n" || c === "\r") {
         if (c === "\r" && src[i + 1] === "\n") i++;
         cur.push(field); field = "";
@@ -39,9 +44,26 @@ export function parseCsv(src: string): Row[] {
     cur.push(field);
     if (cur.some(f => f !== "")) lines.push(cur);
   }
-  if (lines.length === 0) return [];
+  if (lines.length === 0) return { rows: [], warnings: [] };
   const header = lines[0].map(h => h.trim());
-  return lines.slice(1).map(row => {
+  const warnings: string[] = [];
+  const MAX_RAGGED_WARNINGS = 3;
+  const delimName = delimiter === "\t" ? "tab" : delimiter === "," ? "comma" : `'${delimiter}'`;
+  const quoted = delimiter === "\t" ? '"a\tb"' : '"1,238"';
+  let ragged = 0;
+  const rows = lines.slice(1).map((row, idx) => {
+    // A trailing delimiter produces one extra empty field; that is harmless and
+    // renders identically, so only warn when the surplus/deficit is meaningful.
+    const surplusAllEmpty = row.length > header.length && row.slice(header.length).every((f) => f === "");
+    if (row.length !== header.length && !surplusAllEmpty) {
+      ragged++;
+      if (ragged <= MAX_RAGGED_WARNINGS) {
+        warnings.push(
+          `Data row ${idx + 1} has ${row.length} fields but the header has ${header.length} columns — ` +
+          `quote values that contain the ${delimName} (e.g. ${quoted})`,
+        );
+      }
+    }
     const r: Row = {};
     header.forEach((h, i) => {
       const raw = row[i] ?? "";
@@ -49,24 +71,50 @@ export function parseCsv(src: string): Row[] {
     });
     return r;
   });
+  if (ragged > MAX_RAGGED_WARNINGS) {
+    warnings.push(`…and ${ragged - MAX_RAGGED_WARNINGS} more rows with mismatched field counts`);
+  }
+  return { rows, warnings };
+}
+
+export function parseCsv(src: string, delimiter = ","): Row[] {
+  return parseCsvFull(src, delimiter).rows;
 }
 
 export function parseJson(src: string): Row[] {
   const v = JSON.parse(src);
   if (!Array.isArray(v)) throw new Error("JSON data must be an array of objects");
+  for (const item of v) {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) {
+      throw new Error("JSON data must be an array of objects (found a non-object element)");
+    }
+  }
   return v as Row[];
 }
 
-export async function loadDataset(relPath: string, baseDir: string): Promise<Row[]> {
+export async function loadDataset(relPath: string, baseDir: string, warnings?: string[]): Promise<Row[]> {
   const normalizedBase = path.resolve(baseDir);
   const full = path.resolve(normalizedBase, relPath);
   const rel = path.relative(normalizedBase, full);
   if (rel.startsWith("..") || path.isAbsolute(rel)) {
     throw new Error(`Data file path escapes base directory: ${relPath}`);
   }
-  const src = await fs.readFile(full, "utf8");
+  let src: string;
+  try {
+    src = await fs.readFile(full, "utf8");
+  } catch (e) {
+    // Report the author's relative reference, not the absolute path — error
+    // messages end up in shareable rendered HTML.
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") throw new Error(`Data file not found: ${relPath}`);
+    throw new Error(`Cannot read data file '${relPath}'${code ? ` (${code})` : ""}`);
+  }
   const ext = path.extname(full).toLowerCase();
-  if (ext === ".csv" || ext === ".tsv") return parseCsv(src);
+  if (ext === ".csv" || ext === ".tsv") {
+    const res = parseCsvFull(src, ext === ".tsv" ? "\t" : ",");
+    if (warnings) warnings.push(...res.warnings);
+    return res.rows;
+  }
   if (ext === ".json") return parseJson(src);
   throw new Error(`Unsupported data file extension: ${ext}`);
 }

--- a/packages/mdv-core/src/frontmatter.ts
+++ b/packages/mdv-core/src/frontmatter.ts
@@ -5,17 +5,28 @@ export interface FrontmatterResult {
   body: string;
 }
 
+export interface FrontmatterSafeResult extends FrontmatterResult {
+  /** Set when the YAML is invalid; `data` is empty and `body` has the front-matter block stripped. */
+  error?: string;
+}
+
 const FM_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
 
-export function extractFrontmatter(source: string): FrontmatterResult {
+export function extractFrontmatterSafe(source: string): FrontmatterSafeResult {
   const m = source.match(FM_RE);
   if (!m) return { data: {}, body: source };
-  let data: Record<string, unknown>;
+  const body = source.slice(m[0].length);
   try {
     const parsed = yaml.load(m[1]);
-    data = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+    const data = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+    return { data, body };
   } catch (e) {
-    throw new Error(`Invalid front-matter YAML: ${(e as Error).message}`);
+    return { data: {}, body, error: `Invalid front-matter YAML: ${(e as Error).message}` };
   }
-  return { data, body: source.slice(m[0].length) };
+}
+
+export function extractFrontmatter(source: string): FrontmatterResult {
+  const r = extractFrontmatterSafe(source);
+  if (r.error) throw new Error(r.error);
+  return { data: r.data, body: r.body };
 }

--- a/packages/mdv-core/src/index.ts
+++ b/packages/mdv-core/src/index.ts
@@ -8,10 +8,30 @@ export { renderDocument as render } from "./render/html.js";
 export type { MdvDoc, MdvToken, ChartMeta, TableMeta, ContainerMeta, ErrorMeta } from "./ast.js";
 export { THEMES, getTheme, type Theme } from "./themes.js";
 
-export async function renderFile(file: string): Promise<string> {
-  const src = await fs.readFile(file, "utf8");
-  const doc = await parse(src, { baseDir: path.dirname(path.resolve(file)) });
-  return renderDocument(doc);
+export interface RenderResult {
+  html: string;
+  /** Fatal error messages (e.g. invalid front-matter) that rendered as a top banner. */
+  fatals: string[];
+  /** Warning messages (unknown theme/style key, ragged data, unclosed container). */
+  warnings: string[];
 }
 
-export const VERSION = "0.1.0";
+export async function renderFileWithDiagnostics(file: string): Promise<RenderResult> {
+  const src = await fs.readFile(file, "utf8");
+  const doc = await parse(src, { baseDir: path.dirname(path.resolve(file)) });
+  const html = renderDocument(doc);
+  const fatals: string[] = [];
+  const warnings: string[] = [];
+  for (const t of doc.tokens) {
+    if (t.kind !== "error") continue;
+    if (t.meta.severity === "fatal") fatals.push(t.meta.message);
+    else if (t.meta.severity === "warning") warnings.push(t.meta.message);
+  }
+  return { html, fatals, warnings };
+}
+
+export async function renderFile(file: string): Promise<string> {
+  return (await renderFileWithDiagnostics(file)).html;
+}
+
+export const VERSION = "0.2.0";

--- a/packages/mdv-core/src/parser.ts
+++ b/packages/mdv-core/src/parser.ts
@@ -1,53 +1,83 @@
 import MarkdownIt from "markdown-it";
-import { extractFrontmatter } from "./frontmatter.js";
+import { extractFrontmatterSafe } from "./frontmatter.js";
 import { parseInfoString } from "./infostring.js";
-import { parseCsv, parseJson, loadDataset, type Row } from "./data.js";
+import { parseCsvFull, parseJson, loadDataset, type Row } from "./data.js";
+import { preprocess, directiveFromText } from "./preprocess.js";
 import type { MdvDoc, MdvToken, ChartMeta } from "./ast.js";
 
-export const mdInstance = new MarkdownIt({ html: true, linkify: true, typographer: false });
-
-function transformDirectives(body: string): string {
-  const lines = body.split(/\r?\n/);
-  const out: string[] = [];
-  for (const line of lines) {
-    const m = line.match(/^:::\s*(.*)$/);
-    if (m) {
-      const name = m[1].trim();
-      if (name === "") out.push("", "<!--MDV_DIR_CLOSE-->", "");
-      else out.push("", `<!--MDV_DIR_OPEN ${name}-->`, "");
-    } else {
-      out.push(line);
-    }
-  }
-  return out.join("\n");
-}
+// html:false — raw HTML in the authoring surface is escaped, never emitted
+// verbatim into exports ("no selectors, no expressions, no code"). `:::`
+// directives and HTML comments are handled by the fence-aware preprocessor
+// (see preprocess.ts) rather than a markdown-it rule, so they interact
+// correctly with blockquotes, tables and lists.
+export const mdInstance = new MarkdownIt({ html: false, linkify: true, typographer: false });
 
 async function resolveBlockData(
   opts: Record<string, string | boolean>,
   body: string,
   frontmatter: Record<string, unknown>,
   baseDir: string,
-): Promise<Row[]> {
+): Promise<{ rows: Row[]; warnings: string[] }> {
   const format = (opts.format as string) || "csv";
+  const warnings: string[] = [];
   if (typeof opts.data === "string") {
-    const dataMap = (frontmatter.data as Record<string, string>) || {};
-    const ref = dataMap[opts.data];
-    if (!ref) throw new Error(`Dataset '${opts.data}' not declared in front-matter`);
-    return loadDataset(ref, baseDir);
+    const dataMap = (frontmatter.data as Record<string, unknown>) || {};
+    // Object.hasOwn: a dataset name like "constructor" must not resolve through
+    // the prototype chain into a Function.
+    const ref = typeof dataMap === "object" && dataMap && Object.hasOwn(dataMap, opts.data)
+      ? (dataMap as Record<string, unknown>)[opts.data]
+      : undefined;
+    if (typeof ref !== "string") throw new Error(`Dataset '${opts.data}' not declared in front-matter`);
+    const rows = await loadDataset(ref, baseDir, warnings);
+    return { rows, warnings };
   }
-  if (format === "json") return parseJson(body);
-  return parseCsv(body);
+  if (format === "json") return { rows: parseJson(body), warnings };
+  const res = parseCsvFull(body);
+  return { rows: res.rows, warnings: res.warnings };
 }
 
 export async function parse(source: string, opts: { baseDir?: string } = {}): Promise<MdvDoc> {
   const baseDir = opts.baseDir ?? process.cwd();
-  const { data: frontmatter, body } = extractFrontmatter(source);
-  const transformed = transformDirectives(body);
-  const mdTokens = mdInstance.parse(transformed, {});
+  const { data: frontmatter, body, error: fmError } = extractFrontmatterSafe(source);
   const out: MdvToken[] = [];
-  let skipNextClose = false;
+  if (fmError) {
+    // Fatal per spec §6: top-of-doc banner; the body still renders below it.
+    out.push({ kind: "error", meta: { severity: "fatal", message: fmError } });
+  }
+  const mdTokens = mdInstance.parse(preprocess(body), {});
+  const containerStack: string[] = [];
+  const pushWarnings = (warnings: string[]) => {
+    for (const w of warnings) out.push({ kind: "error", meta: { severity: "warning", message: w } });
+  };
 
-  for (const tok of mdTokens) {
+  for (let i = 0; i < mdTokens.length; i++) {
+    const tok = mdTokens[i];
+
+    // A directive sentinel is a standalone paragraph: paragraph_open, inline, paragraph_close.
+    if (tok.type === "paragraph_open" && mdTokens[i + 1]?.type === "inline" && mdTokens[i + 2]?.type === "paragraph_close") {
+      const dir = directiveFromText(mdTokens[i + 1].content);
+      if (dir) {
+        i += 2; // consume the three paragraph tokens
+        if (dir.kind === "open") {
+          if (dir.name === "toc") {
+            out.push({ kind: "toc" });
+            containerStack.push("toc");
+          } else {
+            containerStack.push(dir.name);
+            out.push({ kind: "container-open", meta: { name: dir.name } });
+          }
+        } else {
+          const opened = containerStack.pop();
+          if (opened === undefined) {
+            out.push({ kind: "error", meta: { severity: "warning", message: "Ignored a ':::' close with no open container" } });
+          } else if (opened !== "toc") {
+            out.push({ kind: "container-close" });
+          }
+        }
+        continue;
+      }
+    }
+
     if (tok.type === "fence") {
       const info = parseInfoString(tok.info);
       if (info.lang === "chart") {
@@ -60,7 +90,8 @@ export async function parse(source: string, opts: { baseDir?: string } = {}): Pr
           continue;
         }
         try {
-          const rows = await resolveBlockData(info.opts, tok.content, frontmatter, baseDir);
+          const { rows, warnings } = await resolveBlockData(info.opts, tok.content, frontmatter, baseDir);
+          pushWarnings(warnings);
           out.push({ kind: "chart", meta: { type, opts: info.opts, data: rows } });
         } catch (e) {
           out.push({ kind: "error", meta: { severity: "block", message: (e as Error).message, source: tok.info } });
@@ -69,7 +100,8 @@ export async function parse(source: string, opts: { baseDir?: string } = {}): Pr
       }
       if (info.lang === "table") {
         try {
-          const rows = await resolveBlockData(info.opts, tok.content, frontmatter, baseDir);
+          const { rows, warnings } = await resolveBlockData(info.opts, tok.content, frontmatter, baseDir);
+          pushWarnings(warnings);
           out.push({ kind: "table", meta: { opts: info.opts, data: rows } });
         } catch (e) {
           out.push({ kind: "error", meta: { severity: "block", message: (e as Error).message, source: tok.info } });
@@ -78,7 +110,8 @@ export async function parse(source: string, opts: { baseDir?: string } = {}): Pr
       }
       if (info.lang === "stat") {
         try {
-          const rows = await resolveBlockData(info.opts, tok.content, frontmatter, baseDir);
+          const { rows, warnings } = await resolveBlockData(info.opts, tok.content, frontmatter, baseDir);
+          pushWarnings(warnings);
           out.push({ kind: "stat", meta: { opts: info.opts, data: rows } });
         } catch (e) {
           out.push({ kind: "error", meta: { severity: "block", message: (e as Error).message, source: tok.info } });
@@ -86,25 +119,25 @@ export async function parse(source: string, opts: { baseDir?: string } = {}): Pr
         continue;
       }
     }
-    if (tok.type === "html_block") {
-      const openMatch = tok.content.match(/<!--MDV_DIR_OPEN\s+([^-]+)-->/);
-      if (openMatch) {
-        const name = openMatch[1].trim();
-        if (name === "toc") {
-          out.push({ kind: "toc" });
-          skipNextClose = true;
-          continue;
-        }
-        out.push({ kind: "container-open", meta: { name } });
-        continue;
-      }
-      if (tok.content.includes("<!--MDV_DIR_CLOSE-->")) {
-        if (skipNextClose) { skipNextClose = false; continue; }
-        out.push({ kind: "container-close" });
-        continue;
-      }
-    }
+
     out.push({ kind: "md", token: tok });
   }
+
+  // Auto-close containers left open at end of document so the HTML stays
+  // balanced. Emit every close first, then the warnings, so a warning never
+  // renders *inside* the container it is warning about (e.g. as a phantom
+  // grid cell in `::: columns`).
+  const closeWarnings: string[] = [];
+  while (containerStack.length) {
+    const name = containerStack.pop()!;
+    if (name === "toc") {
+      closeWarnings.push("'::: toc' was never closed — a later ':::' may have been treated as its close");
+      continue;
+    }
+    out.push({ kind: "container-close" });
+    closeWarnings.push(`Container '::: ${name}' was never closed (auto-closed at end of document)`);
+  }
+  for (const w of closeWarnings) out.push({ kind: "error", meta: { severity: "warning", message: w } });
+
   return { frontmatter, tokens: out, baseDir };
 }

--- a/packages/mdv-core/src/preprocess.ts
+++ b/packages/mdv-core/src/preprocess.ts
@@ -1,0 +1,78 @@
+// Fence-aware source preprocessing, run before markdown-it.
+//
+// Two jobs, both of which must respect fenced code blocks so a document that
+// *documents* MDV syntax still degrades cleanly as plain CommonMark:
+//   1. Rewrite column-0 `:::` directive lines into isolated sentinel paragraphs.
+//      Sentinels are plain text (private-use code points) so they survive
+//      `html:false` — unlike the old HTML-comment sentinels, which relied on
+//      `html:true` and let raw markup through.
+//   2. Drop a line that is *entirely* one complete, column-0 HTML comment
+//      (`<!-- … -->`). Under `html:false` markdown-it would otherwise print it
+//      as visible text. The rule is deliberately narrow: inline comments,
+//      multi-line comments, unterminated `<!--`, and indented/code comments are
+//      left untouched, so this never deletes content or corrupts a code span.
+
+// U+E000 / U+E001 are Unicode private-use code points — they never appear in
+// real prose, so a sentinel built from them cannot collide with author text.
+const PUA_A = String.fromCharCode(0xe000);
+const PUA_B = String.fromCharCode(0xe001);
+const OPEN_PREFIX = `${PUA_A}MDVOPEN:`;
+const CLOSE_TEXT = `${PUA_A}MDVCLOSE${PUA_B}`;
+
+export type Directive = { kind: "open"; name: string } | { kind: "close" };
+
+/** Recognise a sentinel produced by {@link preprocess} from a paragraph's text. */
+export function directiveFromText(content: string): Directive | null {
+  if (content === CLOSE_TEXT) return { kind: "close" };
+  if (content.startsWith(OPEN_PREFIX) && content.endsWith(PUA_B)) {
+    return { kind: "open", name: content.slice(OPEN_PREFIX.length, -PUA_B.length) };
+  }
+  return null;
+}
+
+// Fence rules mirror CommonMark so the preprocessor's notion of "inside a fence"
+// cannot drift from markdown-it's (any drift would leak a sentinel into <pre>):
+//   - opener: 0-3 spaces, a run of >=3 backticks or tildes; a backtick fence's
+//     info string may not contain a backtick.
+//   - closer: 0-3 spaces, the same character, at least as long, then only spaces.
+const FENCE_OPEN_RE = /^ {0,3}(`{3,}|~{3,})(.*)$/;
+const FENCE_CLOSE_RE = /^ {0,3}(`+|~+)[ \t]*$/;
+const DIRECTIVE_RE = /^:::[ \t]*(.*)$/;
+const FULL_LINE_COMMENT_RE = /^<!--.*?-->[ \t]*$/;
+
+export function preprocess(body: string): string {
+  const lines = body.split(/\r?\n/);
+  const out: string[] = [];
+  let fenceMarker: string | null = null; // the run that opened the current fence
+
+  for (const line of lines) {
+    if (fenceMarker !== null) {
+      out.push(line);
+      const m = line.match(FENCE_CLOSE_RE);
+      if (m && m[1][0] === fenceMarker[0] && m[1].length >= fenceMarker.length) fenceMarker = null;
+      continue;
+    }
+
+    const fo = line.match(FENCE_OPEN_RE);
+    if (fo && !(fo[1][0] === "`" && fo[2].includes("`"))) {
+      fenceMarker = fo[1];
+      out.push(line);
+      continue;
+    }
+
+    // Directive (column-0 `:::`), matching the historical raw-line regex so
+    // indented / blockquoted / list-nested `:::` stay literal exactly as before.
+    const dm = line.match(DIRECTIVE_RE);
+    if (dm) {
+      const name = dm[1].trim();
+      out.push("", name === "" ? CLOSE_TEXT : `${OPEN_PREFIX}${name}${PUA_B}`, "");
+      continue;
+    }
+
+    if (FULL_LINE_COMMENT_RE.test(line)) continue;
+
+    out.push(line);
+  }
+
+  return out.join("\n");
+}

--- a/packages/mdv-core/src/render/chart-bar.ts
+++ b/packages/mdv-core/src/render/chart-bar.ts
@@ -1,6 +1,6 @@
 import type { ChartMeta } from "../ast.js";
 import type { Theme } from "../themes.js";
-import { escapeHtml, niceTicks, formatNumber, parseFormat } from "./svg-util.js";
+import { escapeHtml, niceTicks, formatNumber, parseFormat, columnSet, numericColumn } from "./svg-util.js";
 
 export function renderBarChart(meta: ChartMeta, theme: Theme): string {
   const xKey = meta.opts.x as string;
@@ -8,13 +8,22 @@ export function renderBarChart(meta: ChartMeta, theme: Theme): string {
   if (!xKey || !yKey) return errBlock("Bar chart requires x= and y= options");
   const rows = meta.data;
   if (!rows.length) return errBlock("Bar chart has no data rows");
+  const cols = columnSet(rows);
+  if (!cols.has(xKey)) return errBlock(`Bar chart: column '${xKey}' not found in data (available: ${[...cols].join(", ")})`);
+  if (!cols.has(yKey)) return errBlock(`Bar chart: column '${yKey}' not found in data (available: ${[...cols].join(", ")})`);
   const labels = rows.map((r) => String(r[xKey] ?? ""));
-  const values = rows.map((r) => Number(r[yKey] ?? 0));
+  const values = numericColumn(rows, yKey);
+  if (typeof values === "string") return errBlock(`Bar chart: ${values}`);
   const yfmt = parseFormat(meta.opts.yFormat);
   const W = 720, H = 360, pad = { t: 30, r: 30, b: 50, l: 70 };
   const iw = W - pad.l - pad.r, ih = H - pad.t - pad.b;
-  const ymin = Math.min(0, ...values);
-  const ymax = Math.max(...values);
+  // The y-domain always includes zero on both sides so bars are anchored to a
+  // zero baseline and all-negative data stays inside the viewBox.
+  let ymin = 0, ymax = 0;
+  for (const v of values) {
+    if (v < ymin) ymin = v;
+    if (v > ymax) ymax = v;
+  }
   const ticks = niceTicks(ymin, ymax, 5);
   const t0 = ticks[0], tN = ticks[ticks.length - 1];
   const yScale = (v: number) => pad.t + ih - ((v - t0) / (tN - t0)) * ih;

--- a/packages/mdv-core/src/render/chart-line.ts
+++ b/packages/mdv-core/src/render/chart-line.ts
@@ -1,14 +1,20 @@
 import type { ChartMeta } from "../ast.js";
 import type { Theme } from "../themes.js";
-import { escapeHtml, niceTicks, formatNumber, parseFormat } from "./svg-util.js";
+import { escapeHtml, niceTicks, formatNumber, parseFormat, columnSet, numericColumn } from "./svg-util.js";
 
 export function renderLineChart(meta: ChartMeta, theme: Theme): string {
   const xKey = meta.opts.x as string;
   const yKey = meta.opts.y as string;
   const seriesKey = meta.opts.series as string | undefined;
-  if (!xKey || !yKey) return `<div class="mdv-error">Line chart requires x= and y= options</div>`;
+  if (!xKey || !yKey) return errBlock("Line chart requires x= and y= options");
   const rows = meta.data;
-  if (!rows.length) return `<div class="mdv-error">Line chart has no data rows</div>`;
+  if (!rows.length) return errBlock("Line chart has no data rows");
+  const cols = columnSet(rows);
+  if (!cols.has(xKey)) return errBlock(`Line chart: column '${xKey}' not found in data (available: ${[...cols].join(", ")})`);
+  if (!cols.has(yKey)) return errBlock(`Line chart: column '${yKey}' not found in data (available: ${[...cols].join(", ")})`);
+  if (seriesKey && !cols.has(seriesKey)) return errBlock(`Line chart: column '${seriesKey}' not found in data (available: ${[...cols].join(", ")})`);
+  const yNums = numericColumn(rows, yKey);
+  if (typeof yNums === "string") return errBlock(`Line chart: ${yNums}`);
 
   const yfmt = parseFormat(meta.opts.yFormat);
   const W = 720, H = 360, pad = { t: 30, r: 110, b: 50, l: 70 };
@@ -35,9 +41,13 @@ export function renderLineChart(meta: ChartMeta, theme: Theme): string {
     const denom = Math.max(1, xUnique.length - 1);
     return pad.l + (idx / denom) * iw;
   };
-  const allYs = rows.map((r) => Number(r[yKey] ?? 0));
-  const ymin = Math.min(0, ...allYs);
-  const ymax = Math.max(...allYs);
+  // Loop (not spread) so very large datasets cannot overflow the call stack.
+  let ymin = 0, ymax = -Infinity;
+  for (const v of yNums) {
+    if (v < ymin) ymin = v;
+    if (v > ymax) ymax = v;
+  }
+  if (ymax < ymin) ymax = ymin;
   const ticks = niceTicks(ymin, ymax, 5);
   const t0 = ticks[0], tN = ticks[ticks.length - 1];
   const yScale = (v: number) => pad.t + ih - ((v - t0) / (tN - t0)) * ih;
@@ -55,6 +65,13 @@ export function renderLineChart(meta: ChartMeta, theme: Theme): string {
       return `${x.toFixed(1)},${y.toFixed(1)}`;
     }).join(" ");
     parts.push(`<polyline fill="none" stroke="${color}" stroke-width="2" points="${pts}"/>`);
+    // A one-point series has no line segment — draw the point so it is visible.
+    if (groupRows.length === 1 && !showPoints) {
+      const r = groupRows[0];
+      const x = xScale(r[xKey]);
+      const y = yScale(Number(r[yKey] ?? 0));
+      parts.push(`<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="3" fill="${color}"><title>${escapeHtml(String(r[xKey]))}: ${formatNumber(Number(r[yKey]), yfmt)}</title></circle>`);
+    }
     if (showPoints) {
       for (const r of groupRows) {
         const x = xScale(r[xKey]);
@@ -80,4 +97,8 @@ export function renderLineChart(meta: ChartMeta, theme: Theme): string {
   const title = (meta.opts.title as string) || "";
   const t = title ? `<div class="mdv-chart-title">${escapeHtml(title)}</div>` : "";
   return `<figure class="mdv-chart">${t}<svg viewBox="0 0 ${W} ${H}" width="100%" xmlns="http://www.w3.org/2000/svg" role="img">${yTicks}${parts.join("")}${xLabels}${legend.join("")}</svg></figure>`;
+}
+
+function errBlock(msg: string): string {
+  return `<div class="mdv-error">${escapeHtml(msg)}</div>`;
 }

--- a/packages/mdv-core/src/render/chart-pie.ts
+++ b/packages/mdv-core/src/render/chart-pie.ts
@@ -1,15 +1,25 @@
 import type { ChartMeta } from "../ast.js";
 import type { Theme } from "../themes.js";
-import { escapeHtml, fmt } from "./svg-util.js";
+import { escapeHtml, fmt, columnSet, numericColumn } from "./svg-util.js";
 
 export function renderPieChart(meta: ChartMeta, theme: Theme): string {
   const labelKey = meta.opts.label as string;
   const valueKey = meta.opts.value as string;
-  if (!labelKey || !valueKey) return `<div class="mdv-error">Pie chart requires label= and value= options</div>`;
+  if (!labelKey || !valueKey) return errBlock("Pie chart requires label= and value= options");
   const rows = meta.data;
-  if (!rows.length) return `<div class="mdv-error">Pie chart has no data rows</div>`;
-  const total = rows.reduce((s, row) => s + Number(row[valueKey] ?? 0), 0);
-  if (total <= 0) return `<div class="mdv-error">Pie chart total is zero</div>`;
+  if (!rows.length) return errBlock("Pie chart has no data rows");
+  const cols = columnSet(rows);
+  if (!cols.has(labelKey)) return errBlock(`Pie chart: column '${labelKey}' not found in data (available: ${[...cols].join(", ")})`);
+  if (!cols.has(valueKey)) return errBlock(`Pie chart: column '${valueKey}' not found in data (available: ${[...cols].join(", ")})`);
+  const vals = numericColumn(rows, valueKey);
+  if (typeof vals === "string") return errBlock(`Pie chart: ${vals}`);
+  for (let i = 0; i < vals.length; i++) {
+    if (vals[i] < 0) {
+      return errBlock(`Pie chart values must be non-negative ('${String(rows[i][labelKey])}' is ${vals[i]})`);
+    }
+  }
+  const total = vals.reduce((s, v) => s + v, 0);
+  if (total <= 0) return errBlock("Pie chart total is zero");
 
   const W = 520, H = 360, cx = 180, cy = 180, r = 140;
   const donut = Boolean(meta.opts.donut);
@@ -17,21 +27,32 @@ export function renderPieChart(meta: ChartMeta, theme: Theme): string {
   const slices: string[] = [];
   const legend: string[] = [];
   rows.forEach((row, i) => {
-    const val = Number(row[valueKey] ?? 0);
+    const val = vals[i];
     const frac = val / total;
-    const a2 = angle + frac * Math.PI * 2;
-    const large = frac > 0.5 ? 1 : 0;
-    const x1 = cx + r * Math.cos(angle), y1 = cy + r * Math.sin(angle);
-    const x2 = cx + r * Math.cos(a2), y2 = cy + r * Math.sin(a2);
     const color = theme.chartPalette[i % theme.chartPalette.length];
-    const d = `M ${cx} ${cy} L ${x1.toFixed(1)} ${y1.toFixed(1)} A ${r} ${r} 0 ${large} 1 ${x2.toFixed(1)} ${y2.toFixed(1)} Z`;
-    slices.push(`<path d="${d}" fill="${color}"><title>${escapeHtml(String(row[labelKey]))}: ${fmt(val)} (${(frac * 100).toFixed(1)}%)</title></path>`);
+    const titleEl = `<title>${escapeHtml(String(row[labelKey]))}: ${fmt(val)} (${(frac * 100).toFixed(1)}%)</title>`;
+    if (frac >= 1 - 1e-9) {
+      // A 100% slice: an arc whose start and end coincide draws nothing, so
+      // render the full disc directly.
+      slices.push(`<circle cx="${cx}" cy="${cy}" r="${r}" fill="${color}">${titleEl}</circle>`);
+    } else if (frac > 0) {
+      const a2 = angle + frac * Math.PI * 2;
+      const large = frac > 0.5 ? 1 : 0;
+      const x1 = cx + r * Math.cos(angle), y1 = cy + r * Math.sin(angle);
+      const x2 = cx + r * Math.cos(a2), y2 = cy + r * Math.sin(a2);
+      const d = `M ${cx} ${cy} L ${x1.toFixed(1)} ${y1.toFixed(1)} A ${r} ${r} 0 ${large} 1 ${x2.toFixed(1)} ${y2.toFixed(1)} Z`;
+      slices.push(`<path d="${d}" fill="${color}">${titleEl}</path>`);
+      angle = a2;
+    }
     legend.push(`<g transform="translate(${cx + r + 40},${40 + i * 22})"><rect width="12" height="12" fill="${color}"/><text x="18" y="10" font-size="12" fill="${theme.textColor}">${escapeHtml(String(row[labelKey]))} (${fmt(val)})</text></g>`);
-    angle = a2;
   });
   if (donut) slices.push(`<circle cx="${cx}" cy="${cy}" r="${r * 0.55}" fill="${theme.background}"/>`);
 
   const title = (meta.opts.title as string) || "";
   const t = title ? `<div class="mdv-chart-title">${escapeHtml(title)}</div>` : "";
   return `<figure class="mdv-chart">${t}<svg viewBox="0 0 ${W} ${H}" width="100%" xmlns="http://www.w3.org/2000/svg" role="img">${slices.join("")}${legend.join("")}</svg></figure>`;
+}
+
+function errBlock(msg: string): string {
+  return `<div class="mdv-error">${escapeHtml(msg)}</div>`;
 }

--- a/packages/mdv-core/src/render/html.ts
+++ b/packages/mdv-core/src/render/html.ts
@@ -30,7 +30,7 @@ export function renderDocument(doc: MdvDoc): string {
   const title = (doc.frontmatter.title as string) || "MDV Document";
 
   const themeWarnings: string[] = [];
-  if (typeof themeName === "string" && !THEMES[themeName]) {
+  if (typeof themeName === "string" && !Object.hasOwn(THEMES, themeName)) {
     themeWarnings.push(`Unknown theme '${themeName}', falling back to '${theme.name}'`);
   }
   const { css: stylesCss, warnings: styleWarnings } = compileStyles(
@@ -40,6 +40,12 @@ export function renderDocument(doc: MdvDoc): string {
   const allWarnings = [...themeWarnings, ...styleWarnings];
 
   const body: string[] = [];
+  // Fatal errors render as a top-of-doc banner (spec §6); the rest of the doc still renders.
+  for (const tok of doc.tokens) {
+    if (tok.kind === "error" && tok.meta.severity === "fatal") {
+      body.push(`<div class="mdv-error mdv-fatal">${escapeHtml(tok.meta.message)}</div>`);
+    }
+  }
   for (const w of allWarnings) body.push(`<div class="mdv-warning">${escapeHtml(w)}</div>`);
 
   // Collect headings for optional TOC.
@@ -86,21 +92,24 @@ export function renderDocument(doc: MdvDoc): string {
       continue;
     }
     flushMd();
-    if (tok.kind === "toc") {
-      body.push(renderToc(headings));
+    // Per-block guard: a failing block renders an inline error banner and
+    // never takes down the rest of the document.
+    if (tok.kind === "toc" || tok.kind === "stat" || tok.kind === "chart" || tok.kind === "table") {
+      try {
+        if (tok.kind === "toc") body.push(renderToc(headings));
+        else if (tok.kind === "stat") body.push(renderStatBlock(tok.meta, theme));
+        else if (tok.kind === "chart") {
+          if (tok.meta.type === "bar") body.push(renderBarChart(tok.meta, theme));
+          else if (tok.meta.type === "line") body.push(renderLineChart(tok.meta, theme));
+          else if (tok.meta.type === "pie") body.push(renderPieChart(tok.meta, theme));
+        } else body.push(renderTable(tok.meta));
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        body.push(`<div class="mdv-error">Failed to render ${tok.kind} block: ${escapeHtml(msg)}</div>`);
+      }
       continue;
     }
-    if (tok.kind === "stat") {
-      body.push(renderStatBlock(tok.meta, theme));
-      continue;
-    }
-    if (tok.kind === "chart") {
-      if (tok.meta.type === "bar") body.push(renderBarChart(tok.meta, theme));
-      else if (tok.meta.type === "line") body.push(renderLineChart(tok.meta, theme));
-      else if (tok.meta.type === "pie") body.push(renderPieChart(tok.meta, theme));
-    } else if (tok.kind === "table") {
-      body.push(renderTable(tok.meta));
-    } else if (tok.kind === "container-open") {
+    if (tok.kind === "container-open") {
       const name = tok.meta.name;
       if (name === "columns") body.push(`<div class="mdv-columns">`);
       else if (name === "col") body.push(`<div class="mdv-col">`);
@@ -108,8 +117,10 @@ export function renderDocument(doc: MdvDoc): string {
     } else if (tok.kind === "container-close") {
       body.push(`</div>`);
     } else if (tok.kind === "error") {
+      if (tok.meta.severity === "fatal") continue; // already rendered at top of doc
+      const cls = tok.meta.severity === "warning" ? "mdv-warning" : "mdv-error";
       body.push(
-        `<div class="mdv-error">${escapeHtml(tok.meta.message)}${tok.meta.source ? ` <code>(${escapeHtml(tok.meta.source)})</code>` : ""}</div>`,
+        `<div class="${cls}">${escapeHtml(tok.meta.message)}${tok.meta.source ? ` <code>(${escapeHtml(tok.meta.source)})</code>` : ""}</div>`,
       );
     }
   }

--- a/packages/mdv-core/src/render/stat.ts
+++ b/packages/mdv-core/src/render/stat.ts
@@ -1,10 +1,14 @@
 import type { TableMeta } from "../ast.js";
 import type { Theme } from "../themes.js";
-import { escapeHtml } from "./svg-util.js";
+import { escapeHtml, columnSet } from "./svg-util.js";
 
 export function renderStatBlock(meta: TableMeta, theme: Theme): string {
   const rows = meta.data;
   if (!rows.length) return `<div class="mdv-error">Stat block has no rows</div>`;
+  const cols = columnSet(rows);
+  if (!cols.has("label") || !cols.has("value")) {
+    return `<div class="mdv-error">${escapeHtml(`Stat block requires 'label' and 'value' columns (found: ${[...cols].join(", ") || "none"})`)}</div>`;
+  }
 
   const cards = rows.map((r) => {
     const label = String(r.label ?? "");

--- a/packages/mdv-core/src/render/svg-util.ts
+++ b/packages/mdv-core/src/render/svg-util.ts
@@ -1,3 +1,39 @@
+import type { Row } from "../data.js";
+
+/** Union of column names across all rows (JSON rows may be ragged). */
+export function columnSet(rows: Row[]): Set<string> {
+  const s = new Set<string>();
+  for (const r of rows) for (const k of Object.keys(r)) s.add(k);
+  return s;
+}
+
+/**
+ * Extract a numeric column. Empty and null cells become 0 (sparse data is
+ * legitimate and rendered as a zero-height mark, as before). A genuinely
+ * non-numeric value — a stray unit suffix like "12%" or a text column — returns
+ * an error string so the caller can show a red banner instead of silently-wrong
+ * output. A misspelled column name is caught earlier by {@link columnSet}.
+ */
+export function numericColumn(rows: Row[], key: string): number[] | string {
+  const out: number[] = [];
+  for (let i = 0; i < rows.length; i++) {
+    const raw = rows[i][key];
+    if (raw == null || raw === "" || (typeof raw === "string" && raw.trim() === "")) {
+      out.push(0);
+      continue;
+    }
+    if (typeof raw === "boolean") {
+      return `column '${key}' has a non-numeric value '${raw}' (data row ${i + 1})`;
+    }
+    const n = typeof raw === "number" ? raw : Number(raw);
+    if (!Number.isFinite(n)) {
+      return `column '${key}' has a non-numeric value '${String(raw)}' (data row ${i + 1})`;
+    }
+    out.push(n);
+  }
+  return out;
+}
+
 export function escapeHtml(s: unknown): string {
   return String(s ?? "").replace(/[&<>"']/g, (c) =>
     ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]!),

--- a/packages/mdv-core/src/styles.ts
+++ b/packages/mdv-core/src/styles.ts
@@ -50,6 +50,14 @@ export function compileStyles(
         continue;
       }
       const v = String(vRaw);
+      // The compiled CSS is emitted verbatim inside a <style> element. A value
+      // containing these characters could close the rule or the element and
+      // inject markup (e.g. `red } </style><script>…`). None are valid in the
+      // flat style vocabulary, so reject the declaration.
+      if (/[<>{}]/.test(v) || v.includes("</")) {
+        warnings.push(`Unsafe character in style value for '${k}' in style '${name}' — ignored`);
+        continue;
+      }
       switch (k) {
         case "color": rules.push(`color: ${v}`); break;
         case "background": rules.push(`background: ${v}`); break;

--- a/packages/mdv-core/src/themes.ts
+++ b/packages/mdv-core/src/themes.ts
@@ -51,6 +51,7 @@ export const THEMES: Record<string, Theme> = {
 };
 
 export function getTheme(name: unknown): Theme {
-  if (typeof name === "string" && THEMES[name]) return THEMES[name];
+  // Object.hasOwn: a name like "constructor" must not resolve via the prototype chain.
+  if (typeof name === "string" && Object.hasOwn(THEMES, name)) return THEMES[name];
   return THEMES.minimal;
 }

--- a/packages/mdv-core/test/data.test.ts
+++ b/packages/mdv-core/test/data.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
-import { parseCsv, parseJson, loadDataset } from "../src/data.ts";
+import { parseCsv, parseCsvFull, parseJson, loadDataset } from "../src/data.ts";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 
@@ -30,4 +30,41 @@ test("loadDataset reads CSV relative to base", async () => {
   assert.equal(rows.length, 4);
   assert.equal(rows[0].region, "North");
   assert.equal(rows[0].sales, 120);
+});
+
+test("loadDataset parses .tsv with tab delimiter", async () => {
+  const rows = await loadDataset("./fixtures/sales.tsv", here);
+  assert.equal(rows.length, 4);
+  assert.equal(rows[0].region, "North");
+  assert.equal(rows[0].sales, 120);
+});
+
+test("loadDataset reports a missing file without leaking the absolute path", async () => {
+  await assert.rejects(
+    () => loadDataset("./fixtures/nope.csv", here),
+    (e: Error) => {
+      assert.match(e.message, /Data file not found: \.\/fixtures\/nope\.csv/);
+      assert.ok(!e.message.includes(here), "message must not contain the absolute base path");
+      return true;
+    },
+  );
+});
+
+test("parseCsvFull warns on rows with mismatched field counts", () => {
+  const { rows, warnings } = parseCsvFull("label,value\nCustomers,1,238\n");
+  assert.equal(rows.length, 1);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /3 fields but the header has 2 columns/);
+});
+
+test("parseCsv supports an explicit delimiter", () => {
+  const rows = parseCsv("a\tb\nX\t1\n", "\t");
+  assert.equal(rows[0].a, "X");
+  assert.equal(rows[0].b, 1);
+});
+
+test("parseJson rejects arrays of non-objects", () => {
+  assert.throws(() => parseJson("[1,2,3]"), /array of objects/);
+  assert.throws(() => parseJson('[["a"]]'), /array of objects/);
+  assert.throws(() => parseJson('[{"a":1},null]'), /array of objects/);
 });

--- a/packages/mdv-core/test/fixtures/sales.tsv
+++ b/packages/mdv-core/test/fixtures/sales.tsv
@@ -1,0 +1,5 @@
+region	sales
+North	120
+South	95
+East	80
+West	140

--- a/packages/mdv-core/test/preprocess.test.ts
+++ b/packages/mdv-core/test/preprocess.test.ts
@@ -1,0 +1,88 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { preprocess, directiveFromText } from "../src/preprocess.ts";
+
+// Round-trip: a directive line becomes an isolated paragraph whose text is a
+// sentinel that directiveFromText decodes.
+function directivesOf(src: string) {
+  return preprocess(src)
+    .split("\n")
+    .map((l) => directiveFromText(l))
+    .filter(Boolean);
+}
+
+test("column-0 ::: name becomes an open directive; bare ::: a close", () => {
+  const dirs = directivesOf("::: callout\n\nHi\n\n:::\n");
+  assert.deepEqual(dirs, [{ kind: "open", name: "callout" }, { kind: "close" }]);
+});
+
+test("::: inside a fenced code block is left literal", () => {
+  const out = preprocess("```\n::: callout\n:::\n```\n");
+  assert.match(out, /::: callout/);
+  assert.equal(directivesOf("```\n::: callout\n:::\n```\n").length, 0);
+});
+
+test("::: inside a tilde fence is left literal", () => {
+  assert.equal(directivesOf("~~~\n::: note\n~~~\n").length, 0);
+});
+
+test("indented ::: (1-3 spaces) is left literal, matching prior behavior", () => {
+  assert.equal(directivesOf("  ::: callout\n").length, 0);
+});
+
+test("::: after a > blockquote prefix is left literal", () => {
+  assert.equal(directivesOf("> ::: note\n").length, 0);
+});
+
+test("a standalone column-0 HTML comment line is dropped", () => {
+  const out = preprocess("before\n<!-- secret note -->\nafter\n");
+  assert.doesNotMatch(out, /secret note/);
+  assert.match(out, /before/);
+  assert.match(out, /after/);
+});
+
+test("an unterminated <!-- never truncates the document", () => {
+  const out = preprocess("The `<!--` sequence.\n\nSecond paragraph.\n\nThird.\n");
+  assert.match(out, /Second paragraph/);
+  assert.match(out, /Third/);
+});
+
+test("an inline HTML comment is left untouched (no code-span corruption)", () => {
+  const out = preprocess("keep <!-- drop --> this\n");
+  assert.match(out, /keep <!-- drop --> this/);
+});
+
+test("a multi-line HTML comment is left untouched (conservative, never destructive)", () => {
+  const out = preprocess("a\n<!-- line one\nline two -->\nb\n");
+  assert.match(out, /line one/);
+  assert.match(out, /line two/);
+});
+
+test("HTML comment inside a fenced code block is preserved", () => {
+  const out = preprocess("```html\n<!-- a comment sample -->\n```\n");
+  assert.match(out, /<!-- a comment sample -->/);
+});
+
+test("a 4-space-indented closing fence does not end the fence (no sentinel leak)", () => {
+  const src = "```\ncode line\n    ```\n::: evil\nmore code\n```\n";
+  const out = preprocess(src);
+  assert.doesNotMatch(out, /MDVOPEN/, "no directive sentinel leaked");
+  assert.doesNotMatch(out, /[\u{e000}\u{e001}]/u, "no private-use chars leaked");
+  assert.match(out, /::: evil/, "the ::: line stays literal inside the fence");
+});
+
+test("a backtick fence whose info string contains a backtick is not treated as a fence", () => {
+  // markdown-it rejects such an opener, so ::: after it must remain a directive.
+  const dirs = directivesOf("```a`b\n::: callout\n:::\n");
+  assert.ok(dirs.some((d) => d && d.kind === "open" && d.name === "callout"));
+});
+
+test("directive names with hyphens round-trip", () => {
+  assert.deepEqual(directivesOf("::: call-out\n"), [{ kind: "open", name: "call-out" }]);
+});
+
+test("closing fence must match the opener length/char", () => {
+  // A shorter run inside a longer fence does not close it.
+  const out = preprocess("````\n```\n::: x\n````\n");
+  assert.equal(directivesOf("````\n```\n::: x\n````\n").length, 0, "::: stays inside the ```` fence");
+});

--- a/packages/mdv-core/test/robustness.test.ts
+++ b/packages/mdv-core/test/robustness.test.ts
@@ -1,0 +1,243 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parse } from "../src/parser.ts";
+import { renderDocument } from "../src/render/html.ts";
+import { extractFrontmatterSafe } from "../src/frontmatter.ts";
+
+async function renderSrc(src: string): Promise<string> {
+  return renderDocument(await parse(src));
+}
+
+function divsBalanced(html: string): boolean {
+  const open = (html.match(/<div/g) || []).length;
+  const close = (html.match(/<\/div>/g) || []).length;
+  return open === close;
+}
+
+// --- CommonMark-superset guarantee -----------------------------------------
+
+test("::: inside a fenced code block stays literal (superset guarantee)", async () => {
+  const src = "```\n::: callout\nHi\n:::\n```\n";
+  const doc = await parse(src);
+  assert.ok(!doc.tokens.some((t) => t.kind === "container-open"), "no container from fenced ::: lines");
+  const html = renderDocument(doc);
+  assert.match(html, /::: callout/);
+  assert.doesNotMatch(html, /MDV_DIR/);
+});
+
+test("raw HTML is escaped, not emitted (html:false)", async () => {
+  const html = await renderSrc("Hello <script>alert(1)</script> world\n");
+  assert.doesNotMatch(html, /<script>alert/);
+  assert.match(html, /&lt;script&gt;/);
+});
+
+// --- Container robustness ---------------------------------------------------
+
+test("container names with hyphens work", async () => {
+  const html = await renderSrc("::: call-out\n\nHi.\n\n:::\n");
+  assert.match(html, /class="mdv-style-call-out"/);
+  assert.ok(divsBalanced(html));
+});
+
+test("stray ::: close renders a warning, not an orphan </div>", async () => {
+  const src = "Hello.\n\n:::\n\nWorld.\n";
+  const doc = await parse(src);
+  const warning = doc.tokens.find((t) => t.kind === "error" && t.meta.severity === "warning");
+  assert.ok(warning, "expected a warning token");
+  const html = renderDocument(doc);
+  assert.match(html, /class="mdv-warning"/);
+  assert.ok(divsBalanced(html), "divs must stay balanced");
+});
+
+test("unclosed container auto-closes at end of document with a warning", async () => {
+  const html = await renderSrc("::: callout\n\nHi.\n");
+  assert.match(html, /never closed/);
+  assert.ok(divsBalanced(html));
+});
+
+test("unclosed ::: toc does not consume the next container's close", async () => {
+  const src = "::: toc\n\n## Section A\n\n::: callout\n\nHi.\n\n:::\n\nAfter.\n";
+  const html = await renderSrc(src);
+  assert.match(html, /mdv-toc/);
+  assert.match(html, /mdv-style-callout/);
+  assert.ok(divsBalanced(html), "callout must be closed by its own :::");
+});
+
+test("::: toc with immediate close renders and stays balanced", async () => {
+  const html = await renderSrc("::: toc\n:::\n\n## One\n\n### Two\n");
+  assert.match(html, /mdv-toc/);
+  assert.match(html, /href="#one"/);
+  assert.ok(divsBalanced(html));
+});
+
+// --- Front-matter fatal handling ---------------------------------------------
+
+test("invalid front-matter YAML renders a fatal top banner and the body still renders", async () => {
+  const src = "---\ntitle: [unclosed\n---\n# Body heading\n";
+  const doc = await parse(src);
+  const fatal = doc.tokens.find((t) => t.kind === "error" && t.meta.severity === "fatal");
+  assert.ok(fatal, "expected a fatal error token");
+  const html = renderDocument(doc);
+  assert.match(html, /mdv-fatal/);
+  assert.match(html, /Invalid front-matter YAML/);
+  assert.match(html, /Body heading/, "body must still render");
+});
+
+test("extractFrontmatterSafe reports the error and strips the block", () => {
+  const r = extractFrontmatterSafe("---\ntitle: [unclosed\n---\n# Body\n");
+  assert.ok(r.error && /front-matter/i.test(r.error));
+  assert.deepEqual(r.data, {});
+  assert.equal(r.body, "# Body\n");
+});
+
+// --- Chart validation --------------------------------------------------------
+
+test("bar chart with misspelled y column renders a red banner, not silent zeros", async () => {
+  const html = await renderSrc("```chart type=bar x=region y=salez\nregion,sales\nNorth,120\n```\n");
+  assert.match(html, /mdv-error/);
+  assert.match(html, /column &#39;salez&#39; not found/);
+  assert.doesNotMatch(html, /<rect/);
+});
+
+test("bar chart with non-numeric y values renders a red banner", async () => {
+  const html = await renderSrc("```chart type=bar x=region y=sales\nregion,sales\nNorth,12%\n```\n");
+  assert.match(html, /mdv-error/);
+  assert.match(html, /non-numeric value/);
+});
+
+test("all-negative bar chart stays inside the plot area", async () => {
+  const html = await renderSrc("```chart type=bar x=a y=b\na,b\nX,-30\nY,-10\nZ,-25\n```\n");
+  assert.match(html, /<rect/);
+  const rects = [...html.matchAll(/<rect x="[^"]+" y="([\d.]+)" width="[^"]+" height="([\d.]+)"/g)];
+  assert.ok(rects.length === 3, "expected 3 bars");
+  for (const m of rects) {
+    const y = Number(m[1]), h = Number(m[2]);
+    assert.ok(y >= 29.5, `bar top ${y} must be at/below the top padding`);
+    assert.ok(y + h <= 310.5, `bar bottom ${y + h} must be above the x-axis area`);
+  }
+});
+
+test("line chart with misspelled series column renders a red banner", async () => {
+  const html = await renderSrc("```chart type=line x=m y=v series=regoin\nm,v,region\nJan,1,N\n```\n");
+  assert.match(html, /column &#39;regoin&#39; not found/);
+});
+
+test("single-datapoint line series renders a visible point marker", async () => {
+  const html = await renderSrc("```chart type=line x=m y=v\nm,v\nJan,42\n```\n");
+  assert.match(html, /<circle/);
+});
+
+test("pie chart with a single 100% slice renders a full disc", async () => {
+  const html = await renderSrc("```chart type=pie label=a value=b\na,b\nAll,50\n```\n");
+  assert.match(html, /<circle[^>]*r="140"/);
+});
+
+test("pie chart with negative values renders a red banner", async () => {
+  const html = await renderSrc("```chart type=pie label=a value=b\na,b\nOne,30\nTwo,-5\n```\n");
+  assert.match(html, /must be non-negative/);
+});
+
+test("stat block without label/value columns renders a red banner", async () => {
+  const html = await renderSrc("```stat\nname,amount\nRevenue,100\n```\n");
+  assert.match(html, /requires &#39;label&#39; and &#39;value&#39; columns/);
+});
+
+// --- Data-layer warnings ------------------------------------------------------
+
+test("ragged CSV row renders a yellow warning and the block still renders", async () => {
+  const src = "```stat\nlabel, value\nCustomers, 1,238\n```\n";
+  const html = await renderSrc(src);
+  assert.match(html, /mdv-warning/);
+  assert.match(html, /fields but the header has/);
+  assert.match(html, /mdv-stat-grid/, "stat block still renders");
+});
+
+// --- Theme robustness ----------------------------------------------------------
+
+test("theme name from Object.prototype falls back with a warning instead of crashing", async () => {
+  const html = await renderSrc("---\ntheme: constructor\n---\n# Hi\n");
+  assert.match(html, /Unknown theme &#39;constructor&#39;/);
+  assert.match(html, /<h1/);
+});
+
+// --- Review findings: blockquote / table / container interaction --------------
+
+test("a blockquote as the last child of a container does not swallow the closing :::", async () => {
+  const html = await renderSrc("::: callout\n\n> quoted\n\n:::\n\nafter\n");
+  assert.ok(divsBalanced(html));
+  assert.match(html, /<blockquote>/);
+  // "after" and any warning must be OUTSIDE the callout div.
+  assert.doesNotMatch(html, /never closed/);
+  const afterIdx = html.indexOf("after");
+  const closeIdx = html.lastIndexOf("</div>");
+  assert.ok(afterIdx > html.indexOf("mdv-style-callout"), "after comes after the callout opens");
+});
+
+test("a directive immediately after a table row still opens the container", async () => {
+  const html = await renderSrc("| a |\n|---|\n| 1 |\n::: note\n\nHi\n\n:::\n");
+  assert.match(html, /<table/);
+  assert.match(html, /class="mdv-style-note"/);
+  assert.doesNotMatch(html, /<td>::: note<\/td>/);
+  assert.ok(divsBalanced(html));
+});
+
+test("blockquote paragraph containing a > ::: line is not split (CommonMark fidelity)", async () => {
+  const html = await renderSrc("> line one\n> ::: note\n> line two\n");
+  // Single paragraph inside the blockquote — one <p>, no container.
+  const pCount = (html.match(/<blockquote>\s*<p>/g) || []).length;
+  assert.equal(pCount, 1);
+  assert.doesNotMatch(html, /mdv-style-note/);
+});
+
+test("HTML comments do not appear as visible text in rendered output", async () => {
+  const html = await renderSrc("Text.\n\n<!-- TODO: private note -->\n\nMore.\n");
+  assert.doesNotMatch(html, /private note/);
+  assert.match(html, /More\./);
+});
+
+// --- Review findings: security ------------------------------------------------
+
+test("front-matter style values cannot break out of the <style> element", async () => {
+  const src =
+    "---\nstyles:\n  evil:\n    color: \"red } </style><script>alert(1)</script>\"\n---\n# Hi\n";
+  const html = await renderSrc(src);
+  assert.doesNotMatch(html, /<script>alert\(1\)<\/script>/);
+  assert.match(html, /Unsafe character in style value/);
+});
+
+// --- Review findings: data robustness ----------------------------------------
+
+test("dataset name from the prototype chain yields the intended banner, not a Node TypeError", async () => {
+  const html = await renderSrc("```chart type=bar x=a y=b data=constructor\n```\n");
+  assert.match(html, /Dataset &#39;constructor&#39; not declared/);
+  assert.doesNotMatch(html, /paths\[1\]/);
+});
+
+test("empty numeric cells render as zero and the chart still draws", async () => {
+  const html = await renderSrc("```chart type=bar x=region y=sales\nregion,sales\nNorth,120\nSouth,\nEast,80\n```\n");
+  assert.match(html, /<rect/);
+  assert.doesNotMatch(html, /<div class="mdv-error"/);
+  assert.equal((html.match(/<rect/g) || []).length, 3, "all three bars render");
+});
+
+test("benign trailing comma does not emit a ragged-row warning", async () => {
+  const html = await renderSrc("```table\na,b\n1,2,\n3,4\n```\n");
+  assert.match(html, /<table/);
+  assert.doesNotMatch(html, /<div class="mdv-warning"/);
+});
+
+// --- Review findings: auto-close ordering & toc -------------------------------
+
+test("unclosed-container warning renders after the closing </div>, not inside the grid", async () => {
+  const html = await renderSrc("::: columns\n\n::: col\n\nA\n");
+  assert.ok(divsBalanced(html));
+  // Both the col- and columns-close </div> come before any warning banner, so
+  // the warning is never a child of the grid.
+  const warnIdx = html.indexOf('<div class="mdv-warning"');
+  assert.ok(warnIdx > html.indexOf("</div></div>"), "warning banners follow the closing divs");
+});
+
+test("unclosed ::: toc emits a diagnostic warning", async () => {
+  const html = await renderSrc("::: toc\n\n## A\n\nBody.\n");
+  assert.match(html, /&#39;::: toc&#39; was never closed/);
+});

--- a/packages/mdv-vscode/package.json
+++ b/packages/mdv-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "mdv-vscode",
   "displayName": "MDV — Markdown Data & Visualization Preview",
   "description": "Live preview for .mdv files: charts, tables, stats, named styles, themes, TOC.",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publisher": "drasimwagan",
   "license": "MIT",
   "icon": "assets/icon.png",
@@ -110,7 +110,7 @@
     "publish": "vsce publish"
   },
   "devDependencies": {
-    "@mdv/core": "0.1.0",
+    "@mdv/core": "0.2.0",
     "@types/vscode": "^1.125.0",
     "@vscode/vsce": "^3.9.2",
     "esbuild": "^0.28.1"


### PR DESCRIPTION
Correctness, security and robustness hardening for MDV, bumping all packages to **0.2.0**. Every fix was found and confirmed through two rounds of adversarial multi-agent review (each finding independently verified before it counted).

## Highlights
- **Security:** `html:false` (raw `<script>` escaped, not emitted); front-matter style values sanitized against `</style>` breakout.
- **CommonMark superset:** `:::` handled by a fence-aware pre-pass — literal inside code fences, correct with blockquotes/tables/lists; HTML comments hidden per-line without ever destroying content.
- **Errors never crash the doc:** invalid front-matter → fatal banner (body still renders); per-block guards; unbalanced `:::` → warning + balanced HTML; `theme: constructor` no longer crashes.
- **Charts/data:** column + numeric validation with red banners; empty cells → 0; bar zero-baseline; pie 100%/negative; `.tsv`; ragged-row warnings; no absolute-path leaks.
- **CLI:** stderr diagnostics + `--strict`; preview binds `127.0.0.1`, validates `--port`, handles `EADDRINUSE`; `--out` makes parent dirs.

## Verification
- `npm ci` + build + **72 tests** (up from 24), `npm audit` **0 vulnerabilities**.
- The two adversarial review passes are captured in the commit; all confirmed blockers/should-fixes resolved and re-verified with their exact repros.

See `CHANGELOG.md` for the full list. Tag `v0.2.0` will be created on merge (source tag only — no Marketplace publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
